### PR TITLE
feat: add helm chart under deploy/helm/librarium-web

### DIFF
--- a/deploy/helm/librarium-web/.gitignore
+++ b/deploy/helm/librarium-web/.gitignore
@@ -1,0 +1,2 @@
+# Pulled in by `helm dependency update`. Tracked via Chart.lock for reproducibility.
+charts/

--- a/deploy/helm/librarium-web/.helmignore
+++ b/deploy/helm/librarium-web/.helmignore
@@ -1,0 +1,15 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.idea/
+.vscode/
+*.tmproj
+*.bak
+*.swp
+*~
+.project
+.tox/
+.flake8
+.mypy_cache/
+__pycache__/

--- a/deploy/helm/librarium-web/Chart.lock
+++ b/deploy/helm/librarium-web/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://fireball1725.github.io/firelabs-helm-common/
+  version: 5.0.3
+digest: sha256:67a6701215db65a670930d37d677d6c964b0d0320502bb76265ada096bdba5ec
+generated: "2026-04-19T10:26:22.122384-04:00"

--- a/deploy/helm/librarium-web/Chart.yaml
+++ b/deploy/helm/librarium-web/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: librarium-web
+description: Librarium Web - React frontend for the self-hosted Librarium library tracker.
+type: application
+
+# Chart version. Bump on template/values changes; does not need to match appVersion.
+version: 0.1.0
+
+# Tracks the librarium-web release. Keep in sync with the pinned image tag in values.yaml.
+appVersion: "26.4.0"
+
+kubeVersion: ">=1.25.0-0"
+
+home: https://github.com/fireball1725/librarium-web
+sources:
+  - https://github.com/fireball1725/librarium-web
+maintainers:
+  - name: fireball1725
+    url: https://github.com/fireball1725
+
+keywords:
+  - librarium
+  - library
+  - books
+  - ebooks
+  - audiobooks
+  - self-hosted
+
+dependencies:
+  - name: common
+    version: 5.0.3
+    repository: https://fireball1725.github.io/firelabs-helm-common/

--- a/deploy/helm/librarium-web/README.md
+++ b/deploy/helm/librarium-web/README.md
@@ -1,0 +1,103 @@
+# librarium-web Helm chart
+
+Helm chart for deploying [librarium-web](https://github.com/fireball1725/librarium-web) to Kubernetes.
+
+Built on top of [firelabs-helm-common](https://github.com/FireBall1725/firelabs-helm-common) (a k8s-at-home library-chart fork). Companion to [`librarium-api`](https://github.com/fireball1725/librarium-api).
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.8+
+- An already-deployed `librarium-api` reachable at `http://librarium-api:8080` in the same namespace
+
+## Install
+
+```bash
+cd deploy/helm/librarium-web
+
+# Fetch the common library chart
+helm dependency update
+
+# Install into the same namespace as librarium-api
+helm install librarium-web . \
+  --namespace librarium
+```
+
+Once the pod is ready, port-forward or set up ingress:
+
+```bash
+kubectl -n librarium port-forward svc/librarium-web 3000:3000
+# then open http://localhost:3000
+```
+
+## Upgrade
+
+```bash
+# Bump the image tag
+helm upgrade librarium-web . \
+  --namespace librarium --reuse-values \
+  --set image.tag=26.4.1
+```
+
+## Uninstall
+
+```bash
+helm uninstall librarium-web -n librarium
+```
+
+The web tier has no PVCs or Secrets — uninstall is clean.
+
+## Configuration
+
+Most of the schema comes from [firelabs-helm-common](https://github.com/FireBall1725/firelabs-helm-common/blob/main/values.yaml). The librarium-specific knobs:
+
+### Image
+
+| Key | Default | Notes |
+|---|---|---|
+| `image.repository` | `ghcr.io/fireball1725/librarium-web` | |
+| `image.tag` | `latest` | Pin in production. |
+| `image.pullPolicy` | `IfNotPresent` | |
+
+### Namespace requirement
+
+The image's bundled `nginx.conf` proxies `/api` and `/health` to `http://librarium-api:8080` by bare service name. That short name only resolves inside the same namespace as `librarium-api`, so both releases **must** share a namespace.
+
+If you need to split namespaces, build a custom image with an `nginx.conf` that points at the fully-qualified service name (e.g. `librarium-api.other-ns.svc.cluster.local`).
+
+### Replicas
+
+The web tier is stateless static nginx — safe to scale horizontally:
+
+```yaml
+controller:
+  replicas: 3
+  strategy: RollingUpdate
+```
+
+### Ingress
+
+Disabled by default. Enable and point at your controller:
+
+```yaml
+ingress:
+  main:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - host: librarium.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: librarium-web-tls
+        hosts: [librarium.example.com]
+```
+
+### Resources
+
+Defaults are light (25m CPU request, 32Mi/128Mi memory) since the pod only serves static files through nginx.
+
+## Chart vs. raw manifests
+
+The raw manifests under [`../kubernetes/`](../kubernetes/) are equivalent for a simple deployment. Use this chart when you want templating or reusable values across environments.

--- a/deploy/helm/librarium-web/templates/NOTES.txt
+++ b/deploy/helm/librarium-web/templates/NOTES.txt
@@ -1,0 +1,23 @@
+Thanks for installing librarium-web.
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Image:     {{ .Values.image.repository }}:{{ .Values.image.tag }}
+
+The web image's bundled nginx.conf proxies /api and /health to
+http://librarium-api:8080 by bare service name. Make sure librarium-api is
+deployed into the same namespace ({{ .Release.Namespace }}) so Kubernetes DNS
+resolves the short name.
+
+Access the UI:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "common.names.fullname" . }} 3000:3000
+
+Then open http://localhost:3000
+
+{{- if .Values.ingress.main.enabled }}
+
+Ingress is enabled. Hosts:
+{{- range .Values.ingress.main.hosts }}
+  - {{ .host }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/librarium-web/templates/common.yaml
+++ b/deploy/helm/librarium-web/templates/common.yaml
@@ -1,0 +1,1 @@
+{{- include "common.all" . -}}

--- a/deploy/helm/librarium-web/values.yaml
+++ b/deploy/helm/librarium-web/values.yaml
@@ -1,0 +1,95 @@
+# Default values for librarium-web.
+#
+# This chart uses firelabs-helm-common as a library chart, so most keys under
+# the top level (image, service, ingress, env, probes, resources, ...) are
+# interpreted by the common chart. See:
+#   https://github.com/FireBall1725/firelabs-helm-common
+#
+# The image bundles nginx serving the Vite static SPA and proxying /api and
+# /health to http://librarium-api:8080 by bare service name. That means the
+# web release MUST be deployed into the same namespace as librarium-api so
+# Kubernetes DNS can resolve the short name. If you need to split namespaces,
+# override nginx.conf in a custom image and point at the fully-qualified
+# service name instead.
+
+global:
+  # Keep release names predictable (otherwise common prepends the release name).
+  fullnameOverride: librarium-web
+
+image:
+  repository: ghcr.io/fireball1725/librarium-web
+  # Pin to a release in production. `latest` is fine for trying the chart.
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Stateless static nginx bundle — safe to scale horizontally and roll without
+# downtime (no PVC, no singleton state).
+controller:
+  replicas: 2
+  strategy: RollingUpdate
+
+# -----------------------------------------------------------------------------
+# HTTP service
+# -----------------------------------------------------------------------------
+service:
+  main:
+    enabled: true
+    type: ClusterIP
+    ports:
+      http:
+        enabled: true
+        primary: true
+        port: 3000
+
+# -----------------------------------------------------------------------------
+# Ingress (disabled by default — most homelabs wire this up separately)
+# -----------------------------------------------------------------------------
+ingress:
+  main:
+    enabled: false
+    # ingressClassName: nginx
+    # annotations: {}
+    # hosts:
+    #   - host: librarium.example.com
+    #     paths:
+    #       - path: /
+    #         pathType: Prefix
+    # tls:
+    #   - secretName: librarium-web-tls
+    #     hosts: [librarium.example.com]
+
+# -----------------------------------------------------------------------------
+# Health probes — a 200 from the SPA index means nginx is alive and serving
+# static assets. There is no dedicated /health endpoint on this tier.
+# -----------------------------------------------------------------------------
+probes:
+  liveness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 15
+      periodSeconds: 30
+  readiness:
+    enabled: true
+    custom: true
+    spec:
+      httpGet:
+        path: /
+        port: http
+      initialDelaySeconds: 3
+      periodSeconds: 10
+  startup:
+    enabled: false
+
+# -----------------------------------------------------------------------------
+# Resources
+# -----------------------------------------------------------------------------
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    memory: 128Mi


### PR DESCRIPTION
## Summary

Mirrors the [librarium-api repo's](https://github.com/FireBall1725/librarium-api) `deploy/helm/` layout so self-hosters have a Helm-based install option for the web tier alongside the raw manifests in `deploy/kubernetes/`.

Built on [firelabs-helm-common](https://github.com/FireBall1725/firelabs-helm-common) v5.0.3 — same library the api chart uses, so the two companion charts stay structurally consistent and easy to reason about together.

Simpler than the api chart since the web tier is stateless static nginx:
- No PVCs, no Secrets, no validation templates
- Just `image` / `service` / `ingress` / `probes` / `resources`
- 2 replicas by default, `RollingUpdate` strategy (safe to scale horizontally)
- Probes hit `/` — a 200 from the SPA index confirms nginx is alive

## Namespace requirement

The image's bundled `nginx.conf` proxies `/api` and `/health` to `http://librarium-api:8080` by bare service name. That short name only resolves inside the same namespace as `librarium-api`, so this chart documents that both releases **must** share a namespace. Split-namespace deployments would require a custom image with the fully-qualified service name baked in.

## What's in the chart

```
deploy/helm/librarium-web/
├── Chart.yaml
├── Chart.lock
├── values.yaml
├── README.md
├── .gitignore          # charts/ is pulled via `helm dependency update`
├── .helmignore
└── templates/
    ├── common.yaml     # just `include "common.all"`
    └── NOTES.txt
```

## Test plan

- [x] `helm dependency update` pulls `common` 5.0.3
- [x] `helm lint .` passes (0 failures, only the non-blocking "icon recommended" info)
- [x] `helm template test .` renders cleanly (Service + Deployment with probes, resources, 2 replicas)
- [ ] End-to-end install + smoke test (will do once merged)

## Related

- The homelab deployment of this same chart is vendored in [`homelab-applications` PR #83](https://github.com/FireBall1725/homelab-applications/pull/83) using "Option A" (copy chart verbatim, override only `values.yaml`). A future upstream refresh is a clean re-copy + reapply-overrides.