### PR TITLE
feat(ai): client surfaces for AI suggestions (26.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ Client-side surfaces for the AI suggestions feature landing in `librarium-api` 2
 
 - **Admin → Connections → AI** page: provider configuration cards driven by server-declared `config_fields` (so new provider backends don't need client changes), test-connection button, active-provider selector, and two-layer AI permissions toggles (reading history / ratings / favourites / full library / taste profile).
 - **Profile → AI Privacy**: master opt-in toggle plus a taste profile form — three-way chip UX (neutral → love → avoid) for genres, themes and formats; single-select era; free-text favourite authors and hard-nos. Empty categories simply aren't sent to the AI.
-- **Admin → Settings → Jobs → AI suggestions**: expandable job card with enabled toggle, cadence preset + custom interval, per-user suggestion caps, taste-profile inclusion switch, per-user run rate limit, and `Run now` trigger.
-- **Dashboard widgets** — "Read next from your library" and "Suggestions to buy" rows, each rendering a horizontal carousel of suggestion cards with cover, reasoning tooltip, and three actions (Interested / Open, Dismiss, Block with book / author scope). Widgets are hidden entirely when empty, so fresh installs stay clean.
-- **`/suggestions`** full-list page with type filter tabs and a user-scoped `Run now` button that respects the admin-configured daily rate limit.
+- **Admin → Settings → Jobs → AI suggestions**: expandable job card with enabled toggle, cadence preset + custom interval, per-type suggestion caps (buy / read-next), taste-profile inclusion switch, per-user run rate limit with an "Unlimited" checkbox for local free providers, and `Run now` trigger.
+- **Dashboard widgets** — "Read next from your library" and "Suggestions to buy" rows, each rendering a horizontal carousel of suggestion cards with cover, reasoning tooltip, and three actions (Interested / Open, Dismiss, Block with book / author scope). Action buttons are bottom-aligned so cards with shorter titles don't have their actions float mid-card. Widgets are hidden entirely when empty, so fresh installs stay clean.
+- **`/suggestions`** full-list page with type filter tabs (All blends buy + read-next by add date, newest first), a user-scoped `Run now` button that respects the admin-configured daily rate limit, and an Osaurus provider configuration surface in `Connections → AI`.
 - Helm chart at `deploy/helm/librarium-web` for self-hosted deployments.
 - `en-CA` and `fr-FR` translations for all new AI-related surfaces.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,19 @@ This project uses **`YY.MM.revision`** (e.g. `26.4.0`, `26.4.1`):
 
 Versions `0.1.0` → `0.13.0` predate this scheme. `26.4.0` is the first release cut under the new format and the first release of `librarium-web` as an independent repository.
 
-## [Unreleased]
+## [26.4.1] — AI-powered book suggestions
+
+Client-side surfaces for the AI suggestions feature landing in `librarium-api` 26.4.1. Also ships the previously-merged Helm chart and associated packaging work.
 
 ### Added
 
-- README, CONTRIBUTING, CI and release workflows, and this CHANGELOG.
+- **Admin → Connections → AI** page: provider configuration cards driven by server-declared `config_fields` (so new provider backends don't need client changes), test-connection button, active-provider selector, and two-layer AI permissions toggles (reading history / ratings / favourites / full library / taste profile).
+- **Profile → AI Privacy**: master opt-in toggle plus a taste profile form — three-way chip UX (neutral → love → avoid) for genres, themes and formats; single-select era; free-text favourite authors and hard-nos. Empty categories simply aren't sent to the AI.
+- **Admin → Settings → Jobs → AI suggestions**: expandable job card with enabled toggle, cadence preset + custom interval, per-user suggestion caps, taste-profile inclusion switch, per-user run rate limit, and `Run now` trigger.
+- **Dashboard widgets** — "Read next from your library" and "Suggestions to buy" rows, each rendering a horizontal carousel of suggestion cards with cover, reasoning tooltip, and three actions (Interested / Open, Dismiss, Block with book / author scope). Widgets are hidden entirely when empty, so fresh installs stay clean.
+- **`/suggestions`** full-list page with type filter tabs and a user-scoped `Run now` button that respects the admin-configured daily rate limit.
+- Helm chart at `deploy/helm/librarium-web` for self-hosted deployments.
+- `en-CA` and `fr-FR` translations for all new AI-related surfaces.
 
 ## [26.4.0] — Initial independent release
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "26.4.1-dev",
+  "version": "26.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/locales/en-CA/common.json
+++ b/public/locales/en-CA/common.json
@@ -15,6 +15,7 @@
   "nav": {
     "dashboard": "Dashboard",
     "libraries": "Libraries",
+    "suggestions": "Suggestions",
     "tools": "Tools",
     "import": "Import",
     "admin": "Admin",

--- a/public/locales/en-CA/common.json
+++ b/public/locales/en-CA/common.json
@@ -19,6 +19,7 @@
     "import": "Import",
     "admin": "Admin",
     "users": "Users",
+    "connections": "Connections",
     "settings": "Settings",
     "profile": "Profile",
     "sign_out": "Sign out",
@@ -39,6 +40,9 @@
     "source": "Source",
     "license": "License",
     "report_issue": "Report an issue"
+  },
+  "connections_nav": {
+    "ai": "AI"
   },
   "settings_nav": {
     "media_management": "Media Management",

--- a/public/locales/en-CA/dashboard.json
+++ b/public/locales/en-CA/dashboard.json
@@ -55,6 +55,9 @@
     "empty": {
       "title": "No suggestions yet",
       "hint": "Opt in from your profile and run a batch — or wait for the next scheduled run."
+    },
+    "runs": {
+      "title": "Recent runs"
     }
   },
   "library_chips": {

--- a/public/locales/en-CA/dashboard.json
+++ b/public/locales/en-CA/dashboard.json
@@ -50,7 +50,12 @@
     "filters": {
       "all": "All ({{count}})",
       "read_next": "Read next ({{count}})",
-      "buy": "To buy ({{count}})"
+      "buy": "To buy ({{count}})",
+      "saved": "Saved ({{count}})"
+    },
+    "saved_empty": {
+      "title": "Nothing saved yet",
+      "hint": "Tap \"Interested\" on a suggestion to pin it here."
     },
     "empty": {
       "title": "No suggestions yet",
@@ -58,6 +63,17 @@
     },
     "runs": {
       "title": "Recent runs"
+    },
+    "progress": {
+      "title": "Generating suggestions…",
+      "starting": "Starting run…",
+      "steps_one": "{{count}} step completed",
+      "steps_other": "{{count}} steps completed"
+    },
+    "quota": {
+      "label": "Runs left: {{remaining}}/{{limit}}",
+      "unlimited": "Runs today: {{used}}",
+      "resets_at": "Next run available {{at}}"
     }
   },
   "library_chips": {

--- a/public/locales/en-CA/dashboard.json
+++ b/public/locales/en-CA/dashboard.json
@@ -35,6 +35,28 @@
     "title": "Picks of the day",
     "empty": "Nothing to pick from — add some novels to your libraries and check back tomorrow."
   },
+  "suggestions": {
+    "buy_title": "Suggestions to buy",
+    "read_next_title": "Read next from your library",
+    "see_all": "See all →"
+  },
+  "suggestions_page": {
+    "title": "Suggestions",
+    "description": "Books your AI assistant thinks you'd enjoy, based on your library and taste profile.",
+    "run_now": "Run now",
+    "running": "Running…",
+    "run_queued": "Suggestion run queued — new picks will appear shortly.",
+    "run_failed": "Couldn't start a suggestion run.",
+    "filters": {
+      "all": "All ({{count}})",
+      "read_next": "Read next ({{count}})",
+      "buy": "To buy ({{count}})"
+    },
+    "empty": {
+      "title": "No suggestions yet",
+      "hint": "Opt in from your profile and run a batch — or wait for the next scheduled run."
+    }
+  },
   "library_chips": {
     "create_first": "+ Create your first library",
     "view_all": "View all →"

--- a/public/locales/fr-FR/common.json
+++ b/public/locales/fr-FR/common.json
@@ -15,6 +15,7 @@
   "nav": {
     "dashboard": "Tableau de bord",
     "libraries": "Bibliothèques",
+    "suggestions": "Suggestions",
     "tools": "Outils",
     "import": "Importer",
     "admin": "Admin",

--- a/public/locales/fr-FR/common.json
+++ b/public/locales/fr-FR/common.json
@@ -19,6 +19,7 @@
     "import": "Importer",
     "admin": "Admin",
     "users": "Utilisateurs",
+    "connections": "Connexions",
     "settings": "Paramètres",
     "profile": "Profil",
     "sign_out": "Déconnexion",
@@ -39,6 +40,9 @@
     "source": "Code source",
     "license": "Licence",
     "report_issue": "Signaler un problème"
+  },
+  "connections_nav": {
+    "ai": "IA"
   },
   "settings_nav": {
     "media_management": "Gestion des médias",

--- a/public/locales/fr-FR/dashboard.json
+++ b/public/locales/fr-FR/dashboard.json
@@ -55,6 +55,9 @@
     "empty": {
       "title": "Aucune suggestion pour l'instant",
       "hint": "Activez l'option dans votre profil et lancez une exécution — ou attendez la prochaine exécution planifiée."
+    },
+    "runs": {
+      "title": "Exécutions récentes"
     }
   },
   "library_chips": {

--- a/public/locales/fr-FR/dashboard.json
+++ b/public/locales/fr-FR/dashboard.json
@@ -35,6 +35,28 @@
     "title": "Sélection du jour",
     "empty": "Rien à suggérer — ajoutez des romans à vos bibliothèques et revenez demain."
   },
+  "suggestions": {
+    "buy_title": "Suggestions d'achat",
+    "read_next_title": "À lire ensuite dans votre bibliothèque",
+    "see_all": "Tout voir →"
+  },
+  "suggestions_page": {
+    "title": "Suggestions",
+    "description": "Livres que votre assistant IA pense que vous apprécierez, selon votre bibliothèque et votre profil de goûts.",
+    "run_now": "Lancer maintenant",
+    "running": "En cours…",
+    "run_queued": "Exécution lancée — les nouvelles suggestions arriveront sous peu.",
+    "run_failed": "Impossible de lancer une exécution.",
+    "filters": {
+      "all": "Tout ({{count}})",
+      "read_next": "À lire ensuite ({{count}})",
+      "buy": "À acheter ({{count}})"
+    },
+    "empty": {
+      "title": "Aucune suggestion pour l'instant",
+      "hint": "Activez l'option dans votre profil et lancez une exécution — ou attendez la prochaine exécution planifiée."
+    }
+  },
   "library_chips": {
     "create_first": "+ Créer votre première bibliothèque",
     "view_all": "Tout voir →"

--- a/public/locales/fr-FR/dashboard.json
+++ b/public/locales/fr-FR/dashboard.json
@@ -50,7 +50,12 @@
     "filters": {
       "all": "Tout ({{count}})",
       "read_next": "À lire ensuite ({{count}})",
-      "buy": "À acheter ({{count}})"
+      "buy": "À acheter ({{count}})",
+      "saved": "Enregistrées ({{count}})"
+    },
+    "saved_empty": {
+      "title": "Aucune suggestion enregistrée",
+      "hint": "Cliquez sur « Intéressé » pour épingler une suggestion ici."
     },
     "empty": {
       "title": "Aucune suggestion pour l'instant",
@@ -58,6 +63,17 @@
     },
     "runs": {
       "title": "Exécutions récentes"
+    },
+    "progress": {
+      "title": "Génération des suggestions…",
+      "starting": "Démarrage de l'exécution…",
+      "steps_one": "{{count}} étape terminée",
+      "steps_other": "{{count}} étapes terminées"
+    },
+    "quota": {
+      "label": "Exécutions restantes : {{remaining}}/{{limit}}",
+      "unlimited": "Exécutions aujourd'hui : {{used}}",
+      "resets_at": "Prochaine exécution disponible {{at}}"
     }
   },
   "library_chips": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,10 @@ import GenresPage from './pages/admin/settings/GenresPage'
 import MediaTypesPage from './pages/admin/settings/MediaTypesPage'
 import ProfilesPage from './pages/admin/settings/ProfilesPage'
 import GeneralPage from './pages/admin/settings/GeneralPage'
+import ConnectionsLayout from './pages/admin/ConnectionsLayout'
+import AIPage from './pages/admin/connections/AIPage'
 import ProfilePage from './pages/ProfilePage'
+import SuggestionsPage from './pages/SuggestionsPage'
 
 function AppRoutes() {
   const { apiReachable } = useAuth()
@@ -41,9 +44,14 @@ function AppRoutes() {
               <Route path="/libraries" element={<LibrariesPage />} />
               <Route path="/import" element={<ImportPage />} />
               <Route path="/profile" element={<ProfilePage />} />
+              <Route path="/suggestions" element={<SuggestionsPage />} />
 
               <Route element={<ProtectedRoute requireAdmin />}>
                 <Route path="/admin/users" element={<UsersPage />} />
+                <Route path="/admin/connections" element={<ConnectionsLayout />}>
+                  <Route index element={<Navigate to="ai" replace />} />
+                  <Route path="ai" element={<AIPage />} />
+                </Route>
                 <Route path="/admin/settings" element={<SettingsLayout />}>
                   <Route index element={<Navigate to="media-management" replace />} />
                   <Route path="metadata"          element={<MetadataPage />} />

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -174,8 +174,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         clearSession()
         throw new ApiError(401, 'Session expired — please log in again')
       }
-      if (res.status === 204) return undefined as T
-      const body = await res.json()
+      if (res.status === 204 || res.status === 202) return undefined as T
+      const text = await res.text()
+      const body = text ? JSON.parse(text) : {}
       if (!res.ok) throw new ApiError(res.status, body.error ?? `HTTP ${res.status}`)
       return body.data as T
     }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -27,6 +27,10 @@ const SETTINGS_ITEMS: Array<{ to: string; labelKey: string }> = [
   { to: '/admin/settings/jobs',             labelKey: 'settings_nav.jobs' },
 ]
 
+const CONNECTIONS_ITEMS: Array<{ to: string; labelKey: string }> = [
+  { to: '/admin/connections/ai', labelKey: 'connections_nav.ai' },
+]
+
 const LIBRARY_SECTIONS: Array<{ section: string; labelKey: string }> = [
   { section: 'books',        labelKey: 'library_nav.books' },
   { section: 'contributors', labelKey: 'library_nav.contributors' },
@@ -42,6 +46,7 @@ export default function Layout() {
   const location = useLocation()
   const { t } = useTranslation()
   const inSettings = location.pathname.startsWith('/admin/settings')
+  const inConnections = location.pathname.startsWith('/admin/connections')
   const libraryMatch = location.pathname.match(/^\/libraries\/([^/]+)(?:\/|$)/)
   const currentLibraryId = libraryMatch?.[1]
   const themeLabels: Record<Theme, string> = {
@@ -187,6 +192,37 @@ export default function Layout() {
                 {t('nav.admin')}
               </p>
               <NavLink to="/admin/users" className={navClass}>{t('nav.users')}</NavLink>
+              <NavLink
+                to="/admin/connections"
+                className={({ isActive }) =>
+                  `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                    isActive || inConnections
+                      ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+                  }`
+                }
+              >
+                {t('nav.connections')}
+              </NavLink>
+              {inConnections && (
+                <div className="mt-1 ml-3 border-l border-gray-200 dark:border-gray-700 pl-3 space-y-0.5">
+                  {CONNECTIONS_ITEMS.map(item => (
+                    <NavLink
+                      key={item.to}
+                      to={item.to}
+                      className={({ isActive }) =>
+                        `block px-2 py-1.5 rounded-md text-sm transition-colors ${
+                          isActive
+                            ? 'text-blue-600 dark:text-blue-400 font-medium'
+                            : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800'
+                        }`
+                      }
+                    >
+                      {t(item.labelKey)}
+                    </NavLink>
+                  ))}
+                </div>
+              )}
               <NavLink
                 to="/admin/settings"
                 className={({ isActive }) =>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -179,6 +179,8 @@ export default function Layout() {
             </div>
           )}
 
+          <NavLink to="/suggestions" className={navClass}>{t('nav.suggestions')}</NavLink>
+
           <div className="pt-4">
             <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
               {t('nav.tools')}

--- a/src/components/RunDetailPanel.tsx
+++ b/src/components/RunDetailPanel.tsx
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useState } from 'react'
+import { useAuth, ApiError } from '../auth/AuthContext'
+import type { SuggestionRunDetail, SuggestionRunEvent, SuggestionRunView } from '../types'
+
+interface RunDetailPanelProps {
+  // Absolute API path for the run detail endpoint:
+  //   /api/v1/me/suggestions/runs/{id}   (user view)
+  //   /api/v1/admin/jobs/ai-suggestions/runs/{id}   (admin view)
+  endpoint: string
+  // Optional compact summary rendered above the event timeline. When the
+  // embedding page already shows the run summary, pass hideSummary.
+  hideSummary?: boolean
+}
+
+// RunDetailPanel fetches and renders one suggestions run: the metadata
+// (provider, tokens, cost, status) and the ordered event timeline. Events
+// are rendered in collapsible groups so a long run doesn't drown the page —
+// the interesting ones (prompt, ai_response, backfill) expand by default,
+// per-candidate enrichment decisions collapse by default.
+export default function RunDetailPanel({ endpoint, hideSummary }: RunDetailPanelProps) {
+  const { callApi } = useAuth()
+  const [detail, setDetail] = useState<SuggestionRunDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setDetail(null)
+    setError(null)
+    callApi<SuggestionRunDetail>(endpoint)
+      .then(d => {
+        if (!cancelled) setDetail(d ?? null)
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof ApiError ? err.message : 'Failed to load run')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [callApi, endpoint])
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-700 dark:text-red-300">
+        {error}
+      </div>
+    )
+  }
+  if (!detail) {
+    return (
+      <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-3 text-sm text-gray-500 dark:text-gray-400">
+        Loading run…
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {!hideSummary && <RunSummary run={detail.run} />}
+      <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+        <div className="border-b border-gray-100 dark:border-gray-800 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Timeline ({detail.events.length} events)
+        </div>
+        <ol className="divide-y divide-gray-100 dark:divide-gray-800">
+          {detail.events.map(e => (
+            <EventRow key={e.seq} event={e} />
+          ))}
+          {detail.events.length === 0 && (
+            <li className="px-3 py-4 text-xs text-gray-500 dark:text-gray-400">
+              No events recorded for this run.
+            </li>
+          )}
+        </ol>
+      </div>
+    </div>
+  )
+}
+
+export function RunSummary({ run }: { run: SuggestionRunView }) {
+  const durationMs = run.finished_at
+    ? new Date(run.finished_at).getTime() - new Date(run.started_at).getTime()
+    : null
+  return (
+    <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 text-xs text-gray-700 dark:text-gray-300">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+        <StatusBadge status={run.status} />
+        <span>
+          <span className="text-gray-500 dark:text-gray-400">Triggered by </span>
+          <span className="font-medium">{run.triggered_by}</span>
+        </span>
+        <span>
+          <span className="text-gray-500 dark:text-gray-400">Provider </span>
+          <span className="font-medium">{run.provider_type}</span>
+          {run.model_id && <span className="text-gray-500 dark:text-gray-400"> ({run.model_id})</span>}
+        </span>
+        <span>
+          <span className="text-gray-500 dark:text-gray-400">Started </span>
+          <span className="font-medium">{new Date(run.started_at).toLocaleString()}</span>
+        </span>
+        {durationMs !== null && (
+          <span>
+            <span className="text-gray-500 dark:text-gray-400">Duration </span>
+            <span className="font-medium">{formatDuration(durationMs)}</span>
+          </span>
+        )}
+        <span>
+          <span className="text-gray-500 dark:text-gray-400">Tokens </span>
+          <span className="font-medium">{run.tokens_in.toLocaleString()} in</span>
+          <span className="text-gray-500 dark:text-gray-400"> / </span>
+          <span className="font-medium">{run.tokens_out.toLocaleString()} out</span>
+        </span>
+        <span>
+          <span className="text-gray-500 dark:text-gray-400">Cost </span>
+          <span className="font-medium">${run.estimated_cost_usd.toFixed(4)}</span>
+        </span>
+      </div>
+      {run.error && (
+        <div className="mt-2 rounded border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-2 text-red-700 dark:text-red-300">
+          <span className="font-semibold">Error:</span> {run.error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const styles =
+    status === 'completed'
+      ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300'
+      : status === 'failed'
+        ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+        : status === 'running'
+          ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300'
+          : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300'
+  return <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium ${styles}`}>{status}</span>
+}
+
+// Events that are visually noisy (one per candidate) start collapsed.
+const DEFAULT_COLLAPSED = new Set(['enrichment_decision', 'read_next_match'])
+
+function EventRow({ event }: { event: SuggestionRunEvent }) {
+  const [open, setOpen] = useState(!DEFAULT_COLLAPSED.has(event.type))
+  return (
+    <li className="px-3 py-2">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex w-full items-start gap-2 text-left"
+      >
+        <svg
+          className={`mt-1 h-3 w-3 flex-shrink-0 text-gray-400 transition-transform ${open ? 'rotate-90' : ''}`}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+            <span className="font-mono text-gray-400 dark:text-gray-500">#{event.seq}</span>
+            <TypeBadge type={event.type} />
+            <EventHeadline event={event} />
+            <span className="ml-auto text-[11px] text-gray-400 dark:text-gray-500">
+              {new Date(event.created_at).toLocaleTimeString()}
+            </span>
+          </div>
+        </div>
+      </button>
+      {open && <EventBody event={event} />}
+    </li>
+  )
+}
+
+function TypeBadge({ type }: { type: string }) {
+  const styles: Record<string, string> = {
+    pipeline_start: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+    pipeline_end: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+    prompt: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300',
+    backfill_prompt: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300',
+    ai_response: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300',
+    backfill_response: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300',
+    enrichment_decision: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300',
+    read_next_match: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300',
+    error: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300',
+  }
+  const cls = styles[type] ?? 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300'
+  return <span className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${cls}`}>{type}</span>
+}
+
+// EventHeadline renders a short one-line summary for known event types so
+// the collapsed timeline is scannable without expanding every row.
+function EventHeadline({ event }: { event: SuggestionRunEvent }) {
+  const c = event.content
+  switch (event.type) {
+    case 'enrichment_decision': {
+      const outcome = str(c.outcome)
+      const title = str(c.title)
+      const reason = str(c.reason)
+      return (
+        <span className="text-gray-700 dark:text-gray-300 truncate">
+          {outcome === 'accepted' ? '✓' : '✗'} {title}
+          {outcome === 'rejected' && reason && (
+            <span className="text-gray-400 dark:text-gray-500"> — {reason}</span>
+          )}
+        </span>
+      )
+    }
+    case 'read_next_match': {
+      const outcome = str(c.outcome)
+      const title = str(c.title)
+      const reason = str(c.reason)
+      return (
+        <span className="text-gray-700 dark:text-gray-300 truncate">
+          {outcome === 'accepted' ? '✓' : '✗'} {title}
+          {outcome === 'rejected' && reason && (
+            <span className="text-gray-400 dark:text-gray-500"> — {reason}</span>
+          )}
+        </span>
+      )
+    }
+    case 'ai_response':
+    case 'backfill_response':
+      return (
+        <span className="text-gray-500 dark:text-gray-400">
+          {num(c.tokens_in)} in / {num(c.tokens_out)} out
+        </span>
+      )
+    case 'pipeline_start':
+      return (
+        <span className="text-gray-500 dark:text-gray-400">
+          {num(c.library_titles)} titles, {num(c.blocks)} blocks
+        </span>
+      )
+    case 'pipeline_end':
+      return (
+        <span className="text-gray-500 dark:text-gray-400">
+          {num(c.buy_count)} buy, {num(c.read_next_count)} read_next
+        </span>
+      )
+    case 'error':
+      return <span className="text-red-600 dark:text-red-400 truncate">{str(c.error)}</span>
+    default:
+      return null
+  }
+}
+
+function EventBody({ event }: { event: SuggestionRunEvent }) {
+  const c = event.content
+  // Prompts and AI responses have a prominent text blob — render it with
+  // a monospace block so newlines are preserved.
+  const textKey =
+    event.type === 'prompt' || event.type === 'backfill_prompt'
+      ? 'prompt'
+      : event.type === 'ai_response' || event.type === 'backfill_response'
+        ? 'text'
+        : null
+
+  return (
+    <div className="mt-2 ml-5 space-y-2">
+      {textKey && typeof c[textKey] === 'string' && (
+        <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950/50 p-2 text-[11px] font-mono text-gray-800 dark:text-gray-200">
+          {String(c[textKey])}
+        </pre>
+      )}
+      {event.type === 'enrichment_decision' && c.metadata_lookup ? (
+        <MetadataLookup lookup={c.metadata_lookup} />
+      ) : null}
+      <details className="text-[11px] text-gray-500 dark:text-gray-400">
+        <summary className="cursor-pointer select-none">Raw JSON</summary>
+        <pre className="mt-1 max-h-64 overflow-auto rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950/50 p-2 font-mono text-gray-700 dark:text-gray-300">
+          {JSON.stringify(c, null, 2)}
+        </pre>
+      </details>
+    </div>
+  )
+}
+
+function MetadataLookup({ lookup }: { lookup: unknown }) {
+  if (!lookup || typeof lookup !== 'object') return null
+  const l = lookup as Record<string, unknown>
+  return (
+    <div className="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950/50 px-2 py-1.5 text-[11px]">
+      <span className="text-gray-500 dark:text-gray-400">Metadata provider resolved: </span>
+      <span className="font-medium text-gray-800 dark:text-gray-200">{str(l.title)}</span>
+      {typeof l.authors === 'string' && l.authors !== '' && (
+        <span className="text-gray-500 dark:text-gray-400"> — {l.authors}</span>
+      )}
+    </div>
+  )
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+function num(v: unknown): number {
+  return typeof v === 'number' ? v : 0
+}
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(1)}s`
+  const m = Math.floor(s / 60)
+  const rs = Math.floor(s % 60)
+  return `${m}m ${rs}s`
+}

--- a/src/components/RunDetailPanel.tsx
+++ b/src/components/RunDetailPanel.tsx
@@ -27,6 +27,8 @@ export default function RunDetailPanel({ endpoint, hideSummary }: RunDetailPanel
   // Track status in a ref so the polling interval can self-terminate without
   // forcing the effect to restart every time detail changes.
   const statusRef = useRef<string | null>(null)
+  const timelineRef = useRef<HTMLOListElement | null>(null)
+  const eventCountRef = useRef(0)
 
   useEffect(() => {
     let cancelled = false
@@ -59,6 +61,20 @@ export default function RunDetailPanel({ endpoint, hideSummary }: RunDetailPanel
     }
   }, [callApi, endpoint])
 
+  // Auto-scroll the timeline to the bottom while the run is live and new
+  // events are coming in. Admins who expand a running job want to watch the
+  // tail — once the run finishes we stop yanking their scroll position.
+  useEffect(() => {
+    const count = detail?.events.length ?? 0
+    const prev = eventCountRef.current
+    eventCountRef.current = count
+    if (statusRef.current !== 'running') return
+    if (count <= prev) return
+    const el = timelineRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [detail])
+
   if (error) {
     return (
       <div className="rounded-md border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-700 dark:text-red-300">
@@ -81,7 +97,10 @@ export default function RunDetailPanel({ endpoint, hideSummary }: RunDetailPanel
         <div className="border-b border-gray-100 dark:border-gray-800 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
           Timeline ({detail.events.length} events)
         </div>
-        <ol className="divide-y divide-gray-100 dark:divide-gray-800">
+        <ol
+          ref={timelineRef}
+          className="max-h-96 overflow-auto divide-y divide-gray-100 dark:divide-gray-800"
+        >
           {detail.events.map(e => (
             <EventRow key={e.seq} event={e} />
           ))}
@@ -155,11 +174,8 @@ function StatusBadge({ status }: { status: string }) {
   return <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium ${styles}`}>{status}</span>
 }
 
-// Events that are visually noisy (one per candidate) start collapsed.
-const DEFAULT_COLLAPSED = new Set(['enrichment_decision', 'read_next_match'])
-
 function EventRow({ event }: { event: SuggestionRunEvent }) {
-  const [open, setOpen] = useState(!DEFAULT_COLLAPSED.has(event.type))
+  const [open, setOpen] = useState(false)
   return (
     <li className="px-3 py-2">
       <button
@@ -237,18 +253,24 @@ function EventHeadline({ event }: { event: SuggestionRunEvent }) {
       )
     }
     case 'ai_response':
-    case 'backfill_response':
+    case 'backfill_response': {
+      const model = str(c.model)
       return (
         <span className="text-gray-500 dark:text-gray-400">
           {num(c.tokens_in)} in / {num(c.tokens_out)} out
+          {model && <span className="ml-2 text-gray-400 dark:text-gray-500">· {model}</span>}
         </span>
       )
-    case 'pipeline_start':
+    }
+    case 'pipeline_start': {
+      const model = str(c.model)
       return (
         <span className="text-gray-500 dark:text-gray-400">
           {num(c.library_titles)} titles, {num(c.blocks)} blocks
+          {model && <span className="ml-2 text-gray-400 dark:text-gray-500">· {model}</span>}
         </span>
       )
+    }
     case 'pipeline_end':
       return (
         <span className="text-gray-500 dark:text-gray-400">
@@ -280,9 +302,9 @@ function EventBody({ event }: { event: SuggestionRunEvent }) {
           {String(c[textKey])}
         </pre>
       )}
-      {event.type === 'enrichment_decision' && c.metadata_lookup ? (
-        <MetadataLookup lookup={c.metadata_lookup} />
-      ) : null}
+      {event.type === 'enrichment_decision' && (
+        <EnrichmentDecisionBody content={c} />
+      )}
       <details className="text-[11px] text-gray-500 dark:text-gray-400">
         <summary className="cursor-pointer select-none">Raw JSON</summary>
         <pre className="mt-1 max-h-64 overflow-auto rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950/50 p-2 font-mono text-gray-700 dark:text-gray-300">
@@ -293,12 +315,64 @@ function EventBody({ event }: { event: SuggestionRunEvent }) {
   )
 }
 
-function MetadataLookup({ lookup }: { lookup: unknown }) {
+// EnrichmentDecisionBody lays out the decision sub-panels in a way that makes
+// the title+author fallback path legible: if we recovered from a bad ISBN,
+// render the recovered book first, then relabel the primary lookup as the
+// rejected candidate. A plain accept (primary ISBN resolved correctly) falls
+// back to the original single-block layout.
+function EnrichmentDecisionBody({ content }: { content: Record<string, unknown> }) {
+  const recoveredVia = str(content.recovered_via)
+  const primaryReject = str(content.primary_reject_reason)
+  const recoveredTitle = str(content.recovered_title)
+  const recoveredAuthor = str(content.recovered_author)
+  const recoveredISBN = str(content.recovered_isbn)
+  const metadataLookup = content.metadata_lookup
+
+  if (recoveredVia) {
+    const primaryLookup =
+      metadataLookup && typeof metadataLookup === 'object'
+        ? (metadataLookup as Record<string, unknown>)
+        : null
+    return (
+      <div className="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950/50 px-2 py-1.5 text-[11px] space-y-1">
+        <div>
+          <span className="text-gray-500 dark:text-gray-400">ISBN lookup failed{primaryReject ? ` (${primaryReject})` : ''}</span>
+          {primaryLookup && str(primaryLookup.title) !== '' && (
+            <>
+              <span className="text-gray-500 dark:text-gray-400"> — returned </span>
+              <span className="font-medium text-gray-800 dark:text-gray-200">{str(primaryLookup.title)}</span>
+              {typeof primaryLookup.authors === 'string' && primaryLookup.authors !== '' && (
+                <span className="text-gray-500 dark:text-gray-400"> — {primaryLookup.authors}</span>
+              )}
+            </>
+          )}
+        </div>
+        <div>
+          <span className="text-gray-500 dark:text-gray-400">Matched via title+author: </span>
+          <span className="font-medium text-gray-800 dark:text-gray-200">{recoveredTitle}</span>
+          {recoveredAuthor && (
+            <span className="text-gray-500 dark:text-gray-400"> — {recoveredAuthor}</span>
+          )}
+          {recoveredISBN && (
+            <span className="text-gray-400 dark:text-gray-500"> · ISBN {recoveredISBN}</span>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  if (metadataLookup && typeof metadataLookup === 'object') {
+    return <MetadataLookup lookup={metadataLookup} label="Metadata provider resolved" />
+  }
+  return null
+}
+
+function MetadataLookup({ lookup, label }: { lookup: unknown; label: string }) {
   if (!lookup || typeof lookup !== 'object') return null
   const l = lookup as Record<string, unknown>
   return (
     <div className="rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950/50 px-2 py-1.5 text-[11px]">
-      <span className="text-gray-500 dark:text-gray-400">Metadata provider resolved: </span>
+      <span className="text-gray-500 dark:text-gray-400">{label}: </span>
       <span className="font-medium text-gray-800 dark:text-gray-200">{str(l.title)}</span>
       {typeof l.authors === 'string' && l.authors !== '' && (
         <span className="text-gray-500 dark:text-gray-400"> — {l.authors}</span>

--- a/src/components/RunDetailPanel.tsx
+++ b/src/components/RunDetailPanel.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 fireball1725
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useAuth, ApiError } from '../auth/AuthContext'
 import type { SuggestionRunDetail, SuggestionRunEvent, SuggestionRunView } from '../types'
 
@@ -24,20 +24,38 @@ export default function RunDetailPanel({ endpoint, hideSummary }: RunDetailPanel
   const { callApi } = useAuth()
   const [detail, setDetail] = useState<SuggestionRunDetail | null>(null)
   const [error, setError] = useState<string | null>(null)
+  // Track status in a ref so the polling interval can self-terminate without
+  // forcing the effect to restart every time detail changes.
+  const statusRef = useRef<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     setDetail(null)
     setError(null)
-    callApi<SuggestionRunDetail>(endpoint)
-      .then(d => {
-        if (!cancelled) setDetail(d ?? null)
-      })
-      .catch(err => {
-        if (!cancelled) setError(err instanceof ApiError ? err.message : 'Failed to load run')
-      })
+    statusRef.current = null
+
+    const load = () =>
+      callApi<SuggestionRunDetail>(endpoint)
+        .then(d => {
+          if (cancelled) return
+          setDetail(d ?? null)
+          statusRef.current = d?.run.status ?? null
+        })
+        .catch(err => {
+          if (!cancelled) setError(err instanceof ApiError ? err.message : 'Failed to load run')
+        })
+
+    load()
+    // Poll while the run is still live; stop once it reaches a terminal state.
+    const id = setInterval(() => {
+      if (cancelled) return
+      const status = statusRef.current
+      if (status && status !== 'running') return
+      load()
+    }, 3000)
     return () => {
       cancelled = true
+      clearInterval(id)
     }
   }, [callApi, endpoint])
 

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -69,16 +69,16 @@ export default function SuggestionCard({ suggestion, onChanged }: SuggestionCard
       : null
 
   return (
-    <div className="w-36 sm:w-40 flex-shrink-0 group relative">
+    <div className="w-36 sm:w-40 flex-shrink-0 group relative flex flex-col">
       <div className="relative">
         <BookCover title={suggestion.title} coverUrl={suggestion.cover_url ?? null} className="w-full" />
         {suggestion.reasoning && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/50 to-transparent text-white text-xs p-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-b-lg">
-            <p className="line-clamp-4">{suggestion.reasoning}</p>
+          <div className="pointer-events-none absolute inset-0 flex items-end bg-black/75 text-white text-xs p-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-lg">
+            <p className="line-clamp-6">{suggestion.reasoning}</p>
           </div>
         )}
       </div>
-      <div className="mt-1.5">
+      <div className="mt-1.5 flex-1">
         <p className="text-xs font-medium text-gray-800 dark:text-gray-200 leading-snug line-clamp-2">
           {suggestion.title}
         </p>

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth, ApiError } from '../auth/AuthContext'
+import { useToast } from './Toast'
+import BookCover from './BookCover'
+import type { SuggestionView } from '../types'
+
+interface SuggestionCardProps {
+  suggestion: SuggestionView
+  onChanged: (id: string, status: string | null) => void
+}
+
+type BlockScope = 'book' | 'author'
+
+// SuggestionCard renders a single AI suggestion with cover + reasoning tooltip
+// and the three actions from the plan: dismiss, block (with scope menu), and
+// the type-specific primary action — "interested" for buy, "open" for read_next
+// (the book is already in the library so we can link straight there).
+export default function SuggestionCard({ suggestion, onChanged }: SuggestionCardProps) {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const [busy, setBusy] = useState(false)
+  const [blockOpen, setBlockOpen] = useState(false)
+
+  const setStatus = async (status: string) => {
+    setBusy(true)
+    try {
+      await callApi(`/api/v1/me/suggestions/${suggestion.id}/status`, {
+        method: 'PUT',
+        body: JSON.stringify({ status }),
+      })
+      onChanged(suggestion.id, status === 'dismissed' ? null : status)
+      if (status === 'dismissed') {
+        showToast('Dismissed', { variant: 'success' })
+      } else if (status === 'interested') {
+        showToast('Marked as interested', { variant: 'success' })
+      }
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to update', { variant: 'error' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const block = async (scope: BlockScope) => {
+    setBusy(true)
+    setBlockOpen(false)
+    try {
+      await callApi(`/api/v1/me/suggestions/${suggestion.id}/block`, {
+        method: 'POST',
+        body: JSON.stringify({ scope }),
+      })
+      onChanged(suggestion.id, null)
+      showToast(scope === 'book' ? 'Blocked this book' : `Blocked anything by ${suggestion.author}`, { variant: 'success' })
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to block', { variant: 'error' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const isReadNext = suggestion.type === 'read_next'
+  const bookHref =
+    suggestion.library_id && suggestion.book_id
+      ? `/libraries/${suggestion.library_id}/books/${suggestion.book_id}`
+      : null
+
+  return (
+    <div className="w-36 sm:w-40 flex-shrink-0 group relative">
+      <div className="relative">
+        <BookCover title={suggestion.title} coverUrl={suggestion.cover_url ?? null} className="w-full" />
+        {suggestion.reasoning && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/50 to-transparent text-white text-xs p-2 opacity-0 group-hover:opacity-100 transition-opacity rounded-b-lg">
+            <p className="line-clamp-4">{suggestion.reasoning}</p>
+          </div>
+        )}
+      </div>
+      <div className="mt-1.5">
+        <p className="text-xs font-medium text-gray-800 dark:text-gray-200 leading-snug line-clamp-2">
+          {suggestion.title}
+        </p>
+        {suggestion.author && (
+          <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500 truncate">
+            {suggestion.author}
+          </p>
+        )}
+      </div>
+      <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
+        {isReadNext && bookHref ? (
+          <Link
+            to={bookHref}
+            className="flex-1 text-center rounded border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-2 py-1 font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
+          >
+            Open
+          </Link>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setStatus('interested')}
+            disabled={busy || suggestion.status === 'interested'}
+            className="flex-1 rounded border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-2 py-1 font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+          >
+            {suggestion.status === 'interested' ? 'Saved ✓' : 'Interested'}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => setStatus('dismissed')}
+          disabled={busy}
+          title="Dismiss"
+          className="rounded border border-gray-300 dark:border-gray-600 px-2 py-1 font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+        >
+          ✕
+        </button>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setBlockOpen(o => !o)}
+            disabled={busy}
+            title="Block"
+            className="rounded border border-gray-300 dark:border-gray-600 px-2 py-1 font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+          >
+            ⊘
+          </button>
+          {blockOpen && (
+            <div className="absolute right-0 z-20 mt-1 w-44 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg">
+              <button
+                type="button"
+                onClick={() => block('book')}
+                className="block w-full text-left px-3 py-2 text-xs hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200"
+              >
+                Block this book
+              </button>
+              {suggestion.author && (
+                <button
+                  type="button"
+                  onClick={() => block('author')}
+                  className="block w-full text-left px-3 py-2 text-xs hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200"
+                >
+                  Block by {suggestion.author}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setBlockOpen(false)}
+                className="block w-full text-left px-3 py-2 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SuggestionsWidget.tsx
+++ b/src/components/SuggestionsWidget.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth, ApiError } from '../auth/AuthContext'
+import type { SuggestionView } from '../types'
+import SuggestionCard from './SuggestionCard'
+
+interface SuggestionsWidgetProps {
+  type: 'buy' | 'read_next'
+  limit?: number
+}
+
+// SuggestionsWidget renders a dashboard row of AI-generated suggestions for a
+// single type. It is hidden entirely when the list is empty so a fresh install
+// stays clean (per the feature plan: no placeholder noise).
+export default function SuggestionsWidget({ type, limit = 5 }: SuggestionsWidgetProps) {
+  const { callApi } = useAuth()
+  const { t } = useTranslation(['dashboard', 'common'])
+  const [items, setItems] = useState<SuggestionView[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    callApi<SuggestionView[]>(`/api/v1/me/suggestions?type=${type}&status=new`)
+      .then(data => {
+        if (!cancelled) setItems(data ?? [])
+      })
+      .catch(err => {
+        if (!cancelled) {
+          setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' }))
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [callApi, type, t])
+
+  const handleChanged = useCallback((id: string, status: string | null) => {
+    setItems(prev => {
+      if (prev === null) return prev
+      if (status === null) return prev.filter(s => s.id !== id)
+      return prev.map(s => (s.id === id ? { ...s, status } : s))
+    })
+  }, [])
+
+  // Hide entirely on error, while loading, or when empty — suggestions are
+  // additive. No point shouting about a failed load on the main dashboard.
+  if (error || items === null || items.length === 0) return null
+
+  const title = type === 'buy' ? t('suggestions.buy_title') : t('suggestions.read_next_title')
+  const visible = items.slice(0, limit)
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+      <div className="flex items-center justify-between px-5 pt-4 pb-2">
+        <h2 className="text-sm font-semibold text-gray-900 dark:text-white">{title}</h2>
+        <Link
+          to={`/suggestions?type=${type}`}
+          className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          {t('suggestions.see_all')}
+        </Link>
+      </div>
+      <div className="px-5 pb-5 flex gap-3 overflow-x-auto scrollbar-thin">
+        {visible.map(s => (
+          <SuggestionCard key={s.id} suggestion={s} onChanged={handleChanged} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/SuggestionsWidget.tsx
+++ b/src/components/SuggestionsWidget.tsx
@@ -10,13 +10,12 @@ import SuggestionCard from './SuggestionCard'
 
 interface SuggestionsWidgetProps {
   type: 'buy' | 'read_next'
-  limit?: number
 }
 
 // SuggestionsWidget renders a dashboard row of AI-generated suggestions for a
 // single type. It is hidden entirely when the list is empty so a fresh install
 // stays clean (per the feature plan: no placeholder noise).
-export default function SuggestionsWidget({ type, limit = 5 }: SuggestionsWidgetProps) {
+export default function SuggestionsWidget({ type }: SuggestionsWidgetProps) {
   const { callApi } = useAuth()
   const { t } = useTranslation(['dashboard', 'common'])
   const [items, setItems] = useState<SuggestionView[] | null>(null)
@@ -51,7 +50,6 @@ export default function SuggestionsWidget({ type, limit = 5 }: SuggestionsWidget
   if (error || items === null || items.length === 0) return null
 
   const title = type === 'buy' ? t('suggestions.buy_title') : t('suggestions.read_next_title')
-  const visible = items.slice(0, limit)
 
   return (
     <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
@@ -65,7 +63,7 @@ export default function SuggestionsWidget({ type, limit = 5 }: SuggestionsWidget
         </Link>
       </div>
       <div className="px-5 pb-5 flex gap-3 overflow-x-auto scrollbar-thin">
-        {visible.map(s => (
+        {items.map(s => (
           <SuggestionCard key={s.id} suggestion={s} onChanged={handleChanged} />
         ))}
       </div>

--- a/src/components/TasteProfileForm.tsx
+++ b/src/components/TasteProfileForm.tsx
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useMemo, useState } from 'react'
+import { useAuth, ApiError } from '../auth/AuthContext'
+import { useToast } from './Toast'
+import type { TasteProfile } from '../types'
+
+// Presets are starting suggestions — user can add custom entries too.
+const GENRE_PRESETS = [
+  'sci-fi', 'fantasy', 'mystery', 'thriller', 'romance',
+  'literary fiction', 'historical fiction', 'horror',
+  'non-fiction', 'biography', 'manga', 'comics', 'young adult',
+]
+
+const THEME_PRESETS = [
+  'cozy', 'dark', 'literary', 'epic', 'humorous',
+  'grimdark', 'hopeful', 'escapist', 'slow-burn', 'fast-paced',
+  'character-driven', 'plot-driven',
+]
+
+const FORMAT_PRESETS = [
+  'novels', 'short stories', 'manga', 'manhwa',
+  'graphic novels', 'light novels', 'non-fiction',
+]
+
+const ERA_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: 'No preference' },
+  { value: 'classics', label: 'Classics' },
+  { value: 'modern', label: 'Modern' },
+  { value: 'current', label: 'Current / recent' },
+]
+
+type ChipState = 'neutral' | 'love' | 'avoid'
+
+interface TriChipProps {
+  label: string
+  state: ChipState
+  onChange: (next: ChipState) => void
+  starred?: boolean
+  onToggleStar?: () => void
+  allowStar?: boolean
+}
+
+// TriChip cycles neutral → love → avoid → neutral on tap. Genres can also
+// be starred as "strong preference" — the star only renders in the `love`
+// state, matching the plan's chip-plus-star design.
+function TriChip({ label, state, onChange, starred, onToggleStar, allowStar }: TriChipProps) {
+  const next: Record<ChipState, ChipState> = {
+    neutral: 'love',
+    love: 'avoid',
+    avoid: 'neutral',
+  }
+  const cls = {
+    neutral:
+      'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700',
+    love:
+      'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-300 dark:border-green-800',
+    avoid:
+      'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-300 dark:border-red-800',
+  }
+  const prefix = state === 'love' ? '♥ ' : state === 'avoid' ? '✕ ' : ''
+  return (
+    <div className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onChange(next[state])}
+        className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${cls[state]}`}
+      >
+        {prefix}{label}
+      </button>
+      {allowStar && state === 'love' && (
+        <button
+          type="button"
+          onClick={onToggleStar}
+          title="Strong preference"
+          className={`p-0.5 text-sm ${starred ? 'text-amber-500' : 'text-gray-300 dark:text-gray-600 hover:text-amber-400'}`}
+        >
+          {starred ? '★' : '☆'}
+        </button>
+      )}
+    </div>
+  )
+}
+
+function chipStateFor(item: string, love?: string[], avoid?: string[]): ChipState {
+  if (avoid?.includes(item)) return 'avoid'
+  if (love?.includes(item)) return 'love'
+  return 'neutral'
+}
+
+function toggleInList(list: string[] | undefined, item: string): string[] {
+  const set = new Set(list ?? [])
+  if (set.has(item)) set.delete(item)
+  else set.add(item)
+  return Array.from(set)
+}
+
+function setChipState(
+  love: string[] | undefined,
+  avoid: string[] | undefined,
+  item: string,
+  next: ChipState,
+): { love: string[]; avoid: string[] } {
+  const l = new Set(love ?? [])
+  const a = new Set(avoid ?? [])
+  l.delete(item)
+  a.delete(item)
+  if (next === 'love') l.add(item)
+  if (next === 'avoid') a.add(item)
+  return { love: Array.from(l), avoid: Array.from(a) }
+}
+
+interface SubcategoryProps {
+  title: string
+  description: string
+  presets: string[]
+  love?: string[]
+  avoid?: string[]
+  allowStar?: boolean
+  favourite?: string[]
+  onChange: (patch: { love: string[]; avoid: string[]; favourite?: string[] }) => void
+}
+
+function ChipSubcategory({
+  title, description, presets, love, avoid, allowStar, favourite, onChange,
+}: SubcategoryProps) {
+  const [customInput, setCustomInput] = useState('')
+
+  // Combined set of chips to display: preset list + any items the user has
+  // tagged love/avoid that aren't in presets (so their custom additions survive).
+  const allItems = useMemo(() => {
+    const s = new Set([...presets, ...(love ?? []), ...(avoid ?? [])])
+    return Array.from(s)
+  }, [presets, love, avoid])
+
+  const handleChipChange = (item: string, next: ChipState) => {
+    const { love: nl, avoid: na } = setChipState(love, avoid, item, next)
+    const nf = favourite?.filter(x => nl.includes(x))
+    onChange({ love: nl, avoid: na, favourite: nf })
+  }
+
+  const toggleStar = (item: string) => {
+    onChange({
+      love: love ?? [],
+      avoid: avoid ?? [],
+      favourite: toggleInList(favourite, item),
+    })
+  }
+
+  const addCustom = () => {
+    const v = customInput.trim().toLowerCase()
+    if (!v) return
+    const { love: nl, avoid: na } = setChipState(love, avoid, v, 'love')
+    onChange({ love: nl, avoid: na, favourite: favourite ?? [] })
+    setCustomInput('')
+  }
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{title}</h3>
+      <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{description}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {allItems.map(item => (
+          <TriChip
+            key={item}
+            label={item}
+            state={chipStateFor(item, love, avoid)}
+            onChange={next => handleChipChange(item, next)}
+            allowStar={allowStar}
+            starred={favourite?.includes(item)}
+            onToggleStar={() => toggleStar(item)}
+          />
+        ))}
+      </div>
+      <div className="mt-3 flex gap-2">
+        <input
+          type="text"
+          value={customInput}
+          onChange={e => setCustomInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addCustom() } }}
+          placeholder={`Add custom ${title.toLowerCase().replace(/s$/, '')}…`}
+          className="flex-1 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        <button
+          type="button"
+          onClick={addCustom}
+          disabled={!customInput.trim()}
+          className="rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface TasteProfileFormProps {
+  disabled?: boolean
+}
+
+export default function TasteProfileForm({ disabled }: TasteProfileFormProps) {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const [profile, setProfile] = useState<TasteProfile>({})
+  const [initial, setInitial] = useState<TasteProfile>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    callApi<TasteProfile>('/api/v1/me/taste-profile')
+      .then(p => {
+        const loaded = p ?? {}
+        setProfile(loaded)
+        setInitial(loaded)
+      })
+      .catch(err => setError(err instanceof ApiError ? err.message : 'Failed to load taste profile'))
+      .finally(() => setLoading(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const dirty = useMemo(
+    () => JSON.stringify(profile) !== JSON.stringify(initial),
+    [profile, initial]
+  )
+
+  const patchGenres = (p: { love: string[]; avoid: string[]; favourite?: string[] }) => {
+    setProfile(prev => ({ ...prev, genres: { love: p.love, avoid: p.avoid, favourite: p.favourite ?? [] } }))
+  }
+  const patchThemes = (p: { love: string[]; avoid: string[] }) => {
+    setProfile(prev => ({ ...prev, themes: { love: p.love, avoid: p.avoid } }))
+  }
+  const patchFormats = (p: { love: string[]; avoid: string[] }) => {
+    setProfile(prev => ({ ...prev, formats: { love: p.love, avoid: p.avoid } }))
+  }
+
+  const handleAuthorsChange = (text: string) => {
+    const list = text.split(',').map(s => s.trim()).filter(Boolean)
+    setProfile(prev => ({ ...prev, favourite_authors: list }))
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await callApi('/api/v1/me/taste-profile', {
+        method: 'PUT',
+        body: JSON.stringify(profile),
+      })
+      setInitial(profile)
+      showToast('Taste profile saved', { variant: 'success' })
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Failed to save'
+      setError(msg)
+      showToast(msg, { variant: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 text-sm text-gray-500 dark:text-gray-400">
+        Loading taste profile…
+      </div>
+    )
+  }
+
+  return (
+    <div className={`space-y-6 ${disabled ? 'opacity-60 pointer-events-none' : ''}`}>
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
+        <ChipSubcategory
+          title="Genres"
+          description="Tap to cycle neutral → love → avoid. Star your strongest favourites."
+          presets={GENRE_PRESETS}
+          love={profile.genres?.love}
+          avoid={profile.genres?.avoid}
+          favourite={profile.genres?.favourite}
+          allowStar
+          onChange={patchGenres}
+        />
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
+        <ChipSubcategory
+          title="Themes &amp; moods"
+          description="What kind of feeling are you after?"
+          presets={THEME_PRESETS}
+          love={profile.themes?.love}
+          avoid={profile.themes?.avoid}
+          onChange={patchThemes}
+        />
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
+        <ChipSubcategory
+          title="Formats"
+          description="Which book formats do you prefer?"
+          presets={FORMAT_PRESETS}
+          love={profile.formats?.love}
+          avoid={profile.formats?.avoid}
+          onChange={patchFormats}
+        />
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Era</h3>
+        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">Time period you gravitate toward.</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {ERA_OPTIONS.map(opt => {
+            const active = (profile.era ?? '') === opt.value
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setProfile(prev => ({ ...prev, era: opt.value }))}
+                className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  active
+                    ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-800'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700'
+                }`}
+              >
+                {opt.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Favourite authors</h3>
+        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">Comma-separated. Three to five works best.</p>
+        <input
+          type="text"
+          value={(profile.favourite_authors ?? []).join(', ')}
+          onChange={e => handleAuthorsChange(e.target.value)}
+          placeholder="e.g. Ursula K. Le Guin, Ted Chiang"
+          className="mt-3 w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Hard nos / content boundaries</h3>
+        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+          Anything the AI should steer away from (free-form).
+        </p>
+        <textarea
+          value={profile.hard_nos ?? ''}
+          onChange={e => setProfile(prev => ({ ...prev, hard_nos: e.target.value }))}
+          rows={3}
+          placeholder="e.g. no explicit content, no novels over 800 pages, no ongoing series"
+          className="mt-3 w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {saving ? 'Saving…' : 'Save taste profile'}
+        </button>
+        {error && <span className="text-sm text-red-600 dark:text-red-400">{error}</span>}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -555,7 +555,7 @@ function RecentlyAddedModule() {
       ) : books === null ? (
         <div className="px-5 pb-5 flex gap-3">
           {[...Array(8)].map((_, i) => (
-            <div key={i} className="w-20 flex-shrink-0">
+            <div key={i} className="w-36 sm:w-40 flex-shrink-0">
               <div className="aspect-[2/3] rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
               <div className="mt-1.5 h-3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
             </div>
@@ -571,16 +571,16 @@ function RecentlyAddedModule() {
             <Link
               key={b.book_id}
               to={`/libraries/${b.library_id}/books/${b.book_id}`}
-              className="flex-shrink-0 w-20 group"
+              className="flex-shrink-0 w-36 sm:w-40 group"
               title={b.title}
             >
               <BookCover
                 title={b.title}
                 coverUrl={b.cover_url}
-                className="w-20"
+                className="w-36 sm:w-40"
                 readStatus={badges && b.read_status ? b.read_status : undefined}
               />
-              <p className="mt-1.5 text-xs font-medium text-gray-800 dark:text-gray-200 leading-snug group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors break-words">
+              <p className="mt-1.5 text-xs font-medium text-gray-800 dark:text-gray-200 leading-snug group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2">
                 {b.title}
               </p>
               {b.authors && (
@@ -626,7 +626,7 @@ function PicksOfTheDayModule() {
       ) : books === null ? (
         <div className="px-5 pb-5 flex gap-3">
           {[...Array(8)].map((_, i) => (
-            <div key={i} className="w-20 flex-shrink-0">
+            <div key={i} className="w-36 sm:w-40 flex-shrink-0">
               <div className="aspect-[2/3] rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
               <div className="mt-1.5 h-3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
             </div>
@@ -642,11 +642,11 @@ function PicksOfTheDayModule() {
             <Link
               key={b.book_id}
               to={`/libraries/${b.library_id}/books/${b.book_id}`}
-              className="flex-shrink-0 w-20 group"
+              className="flex-shrink-0 w-36 sm:w-40 group"
               title={b.title}
             >
-              <BookCover title={b.title} coverUrl={b.cover_url} className="w-20" />
-              <p className="mt-1.5 text-xs font-medium text-gray-800 dark:text-gray-200 leading-snug group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors break-words">
+              <BookCover title={b.title} coverUrl={b.cover_url} className="w-36 sm:w-40" />
+              <p className="mt-1.5 text-xs font-medium text-gray-800 dark:text-gray-200 leading-snug group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors line-clamp-2">
                 {b.title}
               </p>
               {b.authors && (

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -12,6 +12,7 @@ import type {
 } from '../types'
 import PageHeader from '../components/PageHeader'
 import BookCover from '../components/BookCover'
+import SuggestionsWidget from '../components/SuggestionsWidget'
 import { usePageTitle } from '../hooks/usePageTitle'
 
 // ─── Utilities ───────────────────────────────────────────────────────────────
@@ -769,7 +770,11 @@ export default function DashboardPage() {
         {/* Row 3: Picks of the day */}
         <PicksOfTheDayModule />
 
-        {/* Row 4: Recently Added (horizontal scroll) */}
+        {/* Row 4: AI suggestions — hidden entirely when empty */}
+        <SuggestionsWidget type="read_next" />
+        <SuggestionsWidget type="buy" />
+
+        {/* Row 5: Recently Added (horizontal scroll) */}
         <RecentlyAddedModule />
       </div>
     </>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -6,7 +6,8 @@ import type { FormEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
 import { useToast } from '../components/Toast'
-import type { User } from '../types'
+import TasteProfileForm from '../components/TasteProfileForm'
+import type { User, UserAIPrefs } from '../types'
 import { LOCALE_FLAGS, LOCALE_LABELS, LOCALE_STORAGE_KEY, SUPPORTED_LOCALES, type SupportedLocale } from '../i18n'
 
 // ─── Reusable field row ───────────────────────────────────────────────────────
@@ -141,6 +142,34 @@ export default function ProfilePage() {
     }
   }
 
+  // ── AI preferences section ─────────────────────────────────────────────────
+
+  const [aiOptIn, setAiOptIn] = useState(false)
+  const [aiPrefsLoading, setAiPrefsLoading] = useState(true)
+  const [aiOptInSaving, setAiOptInSaving] = useState(false)
+
+  useEffect(() => {
+    callApi<UserAIPrefs>('/api/v1/me/ai-prefs')
+      .then(p => setAiOptIn(Boolean(p?.opt_in)))
+      .catch(() => {})
+      .finally(() => setAiPrefsLoading(false))
+  }, [callApi])
+
+  const handleAiOptInToggle = async (next: boolean) => {
+    setAiOptInSaving(true)
+    try {
+      await callApi('/api/v1/me/ai-prefs', {
+        method: 'PUT',
+        body: JSON.stringify({ opt_in: next }),
+      })
+      setAiOptIn(next)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update AI preferences', { variant: 'error' })
+    } finally {
+      setAiOptInSaving(false)
+    }
+  }
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   const cardClass =
@@ -272,6 +301,59 @@ export default function ProfilePage() {
               </select>
             </div>
           </div>
+        </section>
+
+        {/* ── AI Privacy ── */}
+        <section>
+          {sectionHeading('AI Privacy')}
+          <div className={cardClass}>
+            <div className="flex items-center justify-between px-6 py-4">
+              <div className="min-w-0 mr-6">
+                <p className="text-sm font-medium text-gray-900 dark:text-white">Allow AI features to use my data</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  When on, AI-powered suggestions may read categories the admin has allowed
+                  (reading history, ratings, favourites, full library, and your taste profile
+                  below). Turning this off disables AI suggestions for you entirely.
+                </p>
+              </div>
+              {aiPrefsLoading ? (
+                <div className="h-6 w-11 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => handleAiOptInToggle(!aiOptIn)}
+                  disabled={aiOptInSaving}
+                  className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+                    aiOptIn ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'
+                  } disabled:opacity-60`}
+                  role="switch"
+                  aria-checked={aiOptIn}
+                  aria-label="Allow AI features"
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                      aiOptIn ? 'translate-x-6' : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* ── Taste profile ── */}
+        <section>
+          {sectionHeading('Taste profile')}
+          <p className="mb-3 -mt-2 text-xs text-gray-500 dark:text-gray-400">
+            Optional. Helps the AI generate more personal suggestions. All fields are optional — empty
+            categories aren't sent.
+            {!aiOptIn && !aiPrefsLoading && (
+              <span className="ml-1 text-amber-600 dark:text-amber-400">
+                You haven't opted in to AI features, so this profile won't be used.
+              </span>
+            )}
+          </p>
+          <TasteProfileForm />
         </section>
 
         {/* ── Display preferences ── */}

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -8,9 +8,8 @@ import { useAuth, ApiError } from '../auth/AuthContext'
 import { useToast } from '../components/Toast'
 import PageHeader from '../components/PageHeader'
 import SuggestionCard from '../components/SuggestionCard'
-import RunDetailPanel, { RunSummary } from '../components/RunDetailPanel'
 import { usePageTitle } from '../hooks/usePageTitle'
-import type { SuggestionRunView, SuggestionView } from '../types'
+import type { SuggestionView } from '../types'
 
 type TypeFilter = 'all' | 'buy' | 'read_next'
 
@@ -29,8 +28,10 @@ export default function SuggestionsPage() {
   const [items, setItems] = useState<SuggestionView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [running, setRunning] = useState(false)
-  const [runs, setRuns] = useState<SuggestionRunView[] | null>(null)
-  const [expandedRun, setExpandedRun] = useState<string | null>(null)
+  // Poll-window expiry: set when the user triggers a run so we keep refetching
+  // for a couple minutes while the worker churns. We don't expose run state to
+  // end users — admins watch that in /jobs.
+  const [pollUntil, setPollUntil] = useState<number>(0)
 
   const reload = useCallback(() => {
     setItems(null)
@@ -38,27 +39,26 @@ export default function SuggestionsPage() {
     callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new')
       .then(data => setItems(data ?? []))
       .catch(err => setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' })))
-    callApi<SuggestionRunView[]>('/api/v1/me/suggestions/runs')
-      .then(data => setRuns(data ?? []))
-      .catch(() => setRuns([]))
   }, [callApi, t])
 
   useEffect(() => {
     reload()
   }, [reload])
 
-  // Poll runs while one is running so the user sees the status flip to
-  // completed/failed without a manual refresh.
-  const hasRunning = useMemo(() => (runs ?? []).some(r => r.status === 'running'), [runs])
   useEffect(() => {
-    if (!hasRunning) return
-    const id = setInterval(() => {
-      callApi<SuggestionRunView[]>('/api/v1/me/suggestions/runs')
-        .then(data => setRuns(data ?? []))
+    if (pollUntil === 0) return
+    const tick = () => {
+      if (Date.now() > pollUntil) {
+        setPollUntil(0)
+        return
+      }
+      callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new')
+        .then(data => setItems(data ?? []))
         .catch(() => {})
-    }, 3000)
+    }
+    const id = setInterval(tick, 4000)
     return () => clearInterval(id)
-  }, [hasRunning, callApi])
+  }, [pollUntil, callApi])
 
   const handleChanged = useCallback((id: string, status: string | null) => {
     setItems(prev => {
@@ -82,10 +82,9 @@ export default function SuggestionsPage() {
     try {
       await callApi('/api/v1/me/suggestions/run', { method: 'POST' })
       showToast(t('suggestions_page.run_queued'), { variant: 'success' })
-      // Worker is async; results land when the run completes. We refetch
-      // immediately so in-flight card removals don't leave stale state, but
-      // fresh suggestions may take a beat.
-      reload()
+      // Worker is async; results land when the run completes. Kick off a
+      // polling window so fresh items appear without a manual refresh.
+      setPollUntil(Date.now() + 3 * 60 * 1000)
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : t('suggestions_page.run_failed')
       showToast(msg, { variant: 'error' })
@@ -131,32 +130,6 @@ export default function SuggestionsPage() {
             {t('suggestions_page.filters.buy', { count: buyCount })}
           </FilterTab>
         </div>
-
-        {runs && runs.length > 0 && (
-          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
-            <div className="border-b border-gray-100 dark:border-gray-800 px-4 py-2.5 text-sm font-semibold text-gray-900 dark:text-white">
-              {t('suggestions_page.runs.title')}
-            </div>
-            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
-              {runs.slice(0, 10).map(run => (
-                <li key={run.id} className="px-4 py-3">
-                  <button
-                    type="button"
-                    onClick={() => setExpandedRun(prev => (prev === run.id ? null : run.id))}
-                    className="w-full text-left"
-                  >
-                    <RunSummary run={run} />
-                  </button>
-                  {expandedRun === run.id && (
-                    <div className="mt-3">
-                      <RunDetailPanel endpoint={`/api/v1/me/suggestions/runs/${run.id}`} hideSummary />
-                    </div>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
 
         {error ? (
           <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-4 text-sm text-red-700 dark:text-red-300">

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 fireball1725
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth, ApiError } from '../auth/AuthContext'
@@ -11,7 +11,21 @@ import SuggestionCard from '../components/SuggestionCard'
 import { usePageTitle } from '../hooks/usePageTitle'
 import type { SuggestionView } from '../types'
 
-type TypeFilter = 'all' | 'buy' | 'read_next'
+type TypeFilter = 'all' | 'buy' | 'read_next' | 'saved'
+
+type RunView = {
+  id: string
+  status: 'running' | 'completed' | 'failed' | 'cancelled'
+  started_at: string
+  finished_at?: string
+}
+
+type QuotaView = {
+  used: number
+  limit: number
+  resets_at?: string
+  unlimited: boolean
+}
 
 // SuggestionsPage is the /suggestions overflow surface: users land here from
 // the dashboard widget's "See all" link and can also trigger a user-scoped
@@ -24,20 +38,32 @@ export default function SuggestionsPage() {
 
   const [searchParams, setSearchParams] = useSearchParams()
   const filter = (searchParams.get('type') as TypeFilter | null) ?? 'all'
+  const isSaved = filter === 'saved'
 
-  const [items, setItems] = useState<SuggestionView[] | null>(null)
+  // Keep the two status buckets in separate state so tab counts stay accurate
+  // regardless of which tab is active — the All/Read next/Buy counts are all
+  // drawn from newItems, Saved is drawn from savedItems.
+  const [newItems, setNewItems] = useState<SuggestionView[] | null>(null)
+  const [savedItems, setSavedItems] = useState<SuggestionView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [running, setRunning] = useState(false)
-  // Poll-window expiry: set when the user triggers a run so we keep refetching
-  // for a couple minutes while the worker churns. We don't expose run state to
-  // end users — admins watch that in /jobs.
-  const [pollUntil, setPollUntil] = useState<number>(0)
+  const [quota, setQuota] = useState<QuotaView | null>(null)
+  const [activeRun, setActiveRun] = useState<RunView | null>(null)
+  const [activeEventCount, setActiveEventCount] = useState<number>(0)
+  // Track the last-seen running run so we can detect the running→completed
+  // transition and refresh items/quota when it finishes.
+  const lastRunningIdRef = useRef<string | null>(null)
 
   const reload = useCallback(() => {
-    setItems(null)
     setError(null)
-    callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new')
-      .then(data => setItems(data ?? []))
+    Promise.all([
+      callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new'),
+      callApi<SuggestionView[]>('/api/v1/me/suggestions?status=interested'),
+    ])
+      .then(([fresh, saved]) => {
+        setNewItems(fresh ?? [])
+        setSavedItems(saved ?? [])
+      })
       .catch(err => setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' })))
   }, [callApi, t])
 
@@ -45,28 +71,61 @@ export default function SuggestionsPage() {
     reload()
   }, [reload])
 
+  const refreshQuota = useCallback(() => {
+    callApi<QuotaView>('/api/v1/me/suggestions/quota')
+      .then(data => setQuota(data ?? null))
+      .catch(() => {})
+  }, [callApi])
+
   useEffect(() => {
-    if (pollUntil === 0) return
-    const tick = () => {
-      if (Date.now() > pollUntil) {
-        setPollUntil(0)
+    refreshQuota()
+  }, [refreshQuota])
+
+  // Poll for in-flight runs so we can show progress and auto-refresh items
+  // when a run finishes (covers /run-now kicked from here as well as runs
+  // started by the scheduler or another device).
+  useEffect(() => {
+    let cancelled = false
+    const tick = async () => {
+      let runs: RunView[] | undefined
+      try {
+        runs = await callApi<RunView[]>('/api/v1/me/suggestions/runs')
+      } catch {
         return
       }
-      callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new')
-        .then(data => setItems(data ?? []))
-        .catch(() => {})
+      if (cancelled) return
+      const inflight = runs?.find(r => r.status === 'running') ?? null
+      setActiveRun(inflight)
+      if (inflight) {
+        lastRunningIdRef.current = inflight.id
+        try {
+          const detail = await callApi<{ run: RunView; events: unknown[] }>(`/api/v1/me/suggestions/runs/${inflight.id}`)
+          if (!cancelled) setActiveEventCount(detail?.events?.length ?? 0)
+        } catch {
+          // Leave the previous count if the detail fetch transiently fails.
+        }
+      } else if (lastRunningIdRef.current !== null) {
+        // Just transitioned running → done; refresh everything.
+        lastRunningIdRef.current = null
+        setActiveEventCount(0)
+        reload()
+        refreshQuota()
+      }
     }
+    tick()
     const id = setInterval(tick, 4000)
-    return () => clearInterval(id)
-  }, [pollUntil, callApi])
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [callApi, reload, refreshQuota])
 
-  const handleChanged = useCallback((id: string, status: string | null) => {
-    setItems(prev => {
-      if (prev === null) return prev
-      if (status === null) return prev.filter(s => s.id !== id)
-      return prev.map(s => (s.id === id ? { ...s, status } : s))
-    })
-  }, [])
+  const handleChanged = useCallback((_id: string, _status: string | null) => {
+    // Status changes (interested / dismissed / added / block) shuffle a row
+    // between the two status buckets — simplest to just refetch both. The
+    // endpoint is cheap and avoids bespoke reconciliation logic.
+    reload()
+  }, [reload])
 
   const setFilter = (next: TypeFilter) => {
     if (next === 'all') {
@@ -82,9 +141,9 @@ export default function SuggestionsPage() {
     try {
       await callApi('/api/v1/me/suggestions/run', { method: 'POST' })
       showToast(t('suggestions_page.run_queued'), { variant: 'success' })
-      // Worker is async; results land when the run completes. Kick off a
-      // polling window so fresh items appear without a manual refresh.
-      setPollUntil(Date.now() + 3 * 60 * 1000)
+      // Refresh quota immediately so the counter moves without waiting for the
+      // next poll tick. The runs-poll effect handles completion.
+      refreshQuota()
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : t('suggestions_page.run_failed')
       showToast(msg, { variant: 'error' })
@@ -94,13 +153,18 @@ export default function SuggestionsPage() {
   }
 
   const filtered = useMemo(() => {
-    if (items === null) return null
-    if (filter === 'all') return items
-    return items.filter(s => s.type === filter)
-  }, [items, filter])
+    if (isSaved) return savedItems
+    if (newItems === null) return null
+    if (filter === 'all') return newItems
+    return newItems.filter(s => s.type === filter)
+  }, [newItems, savedItems, isSaved, filter])
 
-  const buyCount = useMemo(() => items?.filter(s => s.type === 'buy').length ?? 0, [items])
-  const readNextCount = useMemo(() => items?.filter(s => s.type === 'read_next').length ?? 0, [items])
+  const buyCount = useMemo(() => newItems?.filter(s => s.type === 'buy').length ?? 0, [newItems])
+  const readNextCount = useMemo(() => newItems?.filter(s => s.type === 'read_next').length ?? 0, [newItems])
+  const savedCount = savedItems?.length ?? 0
+
+  const quotaExhausted = quota !== null && !quota.unlimited && quota.used >= quota.limit
+  const runDisabled = running || activeRun !== null || quotaExhausted
 
   return (
     <>
@@ -108,20 +172,29 @@ export default function SuggestionsPage() {
         title={t('suggestions_page.title')}
         description={t('suggestions_page.description')}
         actions={
-          <button
-            type="button"
-            onClick={runNow}
-            disabled={running}
-            className="rounded-md border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
-          >
-            {running ? t('suggestions_page.running') : t('suggestions_page.run_now')}
-          </button>
+          <div className="flex items-center gap-3">
+            {quota !== null && (
+              <span className="text-xs text-gray-500 dark:text-gray-400" title={quota.resets_at ? t('suggestions_page.quota.resets_at', { at: new Date(quota.resets_at).toLocaleString() }) : undefined}>
+                {quota.unlimited
+                  ? t('suggestions_page.quota.unlimited', { used: quota.used })
+                  : t('suggestions_page.quota.label', { remaining: Math.max(0, quota.limit - quota.used), limit: quota.limit })}
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={runNow}
+              disabled={runDisabled}
+              className="rounded-md border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+            >
+              {running || activeRun !== null ? t('suggestions_page.running') : t('suggestions_page.run_now')}
+            </button>
+          </div>
         }
       />
       <div className="p-4 sm:p-6 space-y-4 max-w-screen-2xl mx-auto">
         <div className="flex items-center gap-2">
           <FilterTab active={filter === 'all'} onClick={() => setFilter('all')}>
-            {t('suggestions_page.filters.all', { count: items?.length ?? 0 })}
+            {t('suggestions_page.filters.all', { count: newItems?.length ?? 0 })}
           </FilterTab>
           <FilterTab active={filter === 'read_next'} onClick={() => setFilter('read_next')}>
             {t('suggestions_page.filters.read_next', { count: readNextCount })}
@@ -129,7 +202,29 @@ export default function SuggestionsPage() {
           <FilterTab active={filter === 'buy'} onClick={() => setFilter('buy')}>
             {t('suggestions_page.filters.buy', { count: buyCount })}
           </FilterTab>
+          <FilterTab active={filter === 'saved'} onClick={() => setFilter('saved')}>
+            {t('suggestions_page.filters.saved', { count: savedCount })}
+          </FilterTab>
         </div>
+
+        {activeRun && (
+          <div className="flex items-center gap-3 rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-950/40 px-4 py-3">
+            <svg className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400 flex-shrink-0" viewBox="0 0 24 24" fill="none">
+              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+              <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+            </svg>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+                {t('suggestions_page.progress.title')}
+              </p>
+              <p className="text-xs text-blue-700 dark:text-blue-300">
+                {activeEventCount > 0
+                  ? t('suggestions_page.progress.steps', { count: activeEventCount })
+                  : t('suggestions_page.progress.starting')}
+              </p>
+            </div>
+          </div>
+        )}
 
         {error ? (
           <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-4 text-sm text-red-700 dark:text-red-300">
@@ -148,10 +243,10 @@ export default function SuggestionsPage() {
         ) : filtered.length === 0 ? (
           <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 p-8 text-center">
             <p className="text-sm font-medium text-gray-900 dark:text-white">
-              {t('suggestions_page.empty.title')}
+              {t(isSaved ? 'suggestions_page.saved_empty.title' : 'suggestions_page.empty.title')}
             </p>
             <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              {t('suggestions_page.empty.hint')}
+              {t(isSaved ? 'suggestions_page.saved_empty.hint' : 'suggestions_page.empty.hint')}
             </p>
           </div>
         ) : (

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -120,7 +120,7 @@ export default function SuggestionsPage() {
     }
   }, [callApi, reload, refreshQuota])
 
-  const handleChanged = useCallback((_id: string, _status: string | null) => {
+  const handleChanged = useCallback(() => {
     // Status changes (interested / dismissed / added / block) shuffle a row
     // between the two status buckets — simplest to just refetch both. The
     // endpoint is cheap and avoids bespoke reconciliation logic.

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -8,8 +8,9 @@ import { useAuth, ApiError } from '../auth/AuthContext'
 import { useToast } from '../components/Toast'
 import PageHeader from '../components/PageHeader'
 import SuggestionCard from '../components/SuggestionCard'
+import RunDetailPanel, { RunSummary } from '../components/RunDetailPanel'
 import { usePageTitle } from '../hooks/usePageTitle'
-import type { SuggestionView } from '../types'
+import type { SuggestionRunView, SuggestionView } from '../types'
 
 type TypeFilter = 'all' | 'buy' | 'read_next'
 
@@ -28,6 +29,8 @@ export default function SuggestionsPage() {
   const [items, setItems] = useState<SuggestionView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [running, setRunning] = useState(false)
+  const [runs, setRuns] = useState<SuggestionRunView[] | null>(null)
+  const [expandedRun, setExpandedRun] = useState<string | null>(null)
 
   const reload = useCallback(() => {
     setItems(null)
@@ -35,11 +38,27 @@ export default function SuggestionsPage() {
     callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new')
       .then(data => setItems(data ?? []))
       .catch(err => setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' })))
+    callApi<SuggestionRunView[]>('/api/v1/me/suggestions/runs')
+      .then(data => setRuns(data ?? []))
+      .catch(() => setRuns([]))
   }, [callApi, t])
 
   useEffect(() => {
     reload()
   }, [reload])
+
+  // Poll runs while one is running so the user sees the status flip to
+  // completed/failed without a manual refresh.
+  const hasRunning = useMemo(() => (runs ?? []).some(r => r.status === 'running'), [runs])
+  useEffect(() => {
+    if (!hasRunning) return
+    const id = setInterval(() => {
+      callApi<SuggestionRunView[]>('/api/v1/me/suggestions/runs')
+        .then(data => setRuns(data ?? []))
+        .catch(() => {})
+    }, 3000)
+    return () => clearInterval(id)
+  }, [hasRunning, callApi])
 
   const handleChanged = useCallback((id: string, status: string | null) => {
     setItems(prev => {
@@ -112,6 +131,32 @@ export default function SuggestionsPage() {
             {t('suggestions_page.filters.buy', { count: buyCount })}
           </FilterTab>
         </div>
+
+        {runs && runs.length > 0 && (
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+            <div className="border-b border-gray-100 dark:border-gray-800 px-4 py-2.5 text-sm font-semibold text-gray-900 dark:text-white">
+              {t('suggestions_page.runs.title')}
+            </div>
+            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+              {runs.slice(0, 10).map(run => (
+                <li key={run.id} className="px-4 py-3">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedRun(prev => (prev === run.id ? null : run.id))}
+                    className="w-full text-left"
+                  >
+                    <RunSummary run={run} />
+                  </button>
+                  {expandedRun === run.id && (
+                    <div className="mt-3">
+                      <RunDetailPanel endpoint={`/api/v1/me/suggestions/runs/${run.id}`} hideSummary />
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
 
         {error ? (
           <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-4 text-sm text-red-700 dark:text-red-300">

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { useAuth, ApiError } from '../auth/AuthContext'
+import { useToast } from '../components/Toast'
+import PageHeader from '../components/PageHeader'
+import SuggestionCard from '../components/SuggestionCard'
+import { usePageTitle } from '../hooks/usePageTitle'
+import type { SuggestionView } from '../types'
+
+type TypeFilter = 'all' | 'buy' | 'read_next'
+
+// SuggestionsPage is the /suggestions overflow surface: users land here from
+// the dashboard widget's "See all" link and can also trigger a user-scoped
+// regen. The dashboard remains the primary surface.
+export default function SuggestionsPage() {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const { t } = useTranslation(['dashboard', 'common'])
+  usePageTitle(t('suggestions_page.title'))
+
+  const [searchParams, setSearchParams] = useSearchParams()
+  const filter = (searchParams.get('type') as TypeFilter | null) ?? 'all'
+
+  const [items, setItems] = useState<SuggestionView[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [running, setRunning] = useState(false)
+
+  const reload = useCallback(() => {
+    setItems(null)
+    setError(null)
+    callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new')
+      .then(data => setItems(data ?? []))
+      .catch(err => setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' })))
+  }, [callApi, t])
+
+  useEffect(() => {
+    reload()
+  }, [reload])
+
+  const handleChanged = useCallback((id: string, status: string | null) => {
+    setItems(prev => {
+      if (prev === null) return prev
+      if (status === null) return prev.filter(s => s.id !== id)
+      return prev.map(s => (s.id === id ? { ...s, status } : s))
+    })
+  }, [])
+
+  const setFilter = (next: TypeFilter) => {
+    if (next === 'all') {
+      searchParams.delete('type')
+    } else {
+      searchParams.set('type', next)
+    }
+    setSearchParams(searchParams, { replace: true })
+  }
+
+  const runNow = async () => {
+    setRunning(true)
+    try {
+      await callApi('/api/v1/me/suggestions/run', { method: 'POST' })
+      showToast(t('suggestions_page.run_queued'), { variant: 'success' })
+      // Worker is async; results land when the run completes. We refetch
+      // immediately so in-flight card removals don't leave stale state, but
+      // fresh suggestions may take a beat.
+      reload()
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : t('suggestions_page.run_failed')
+      showToast(msg, { variant: 'error' })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const filtered = useMemo(() => {
+    if (items === null) return null
+    if (filter === 'all') return items
+    return items.filter(s => s.type === filter)
+  }, [items, filter])
+
+  const buyCount = useMemo(() => items?.filter(s => s.type === 'buy').length ?? 0, [items])
+  const readNextCount = useMemo(() => items?.filter(s => s.type === 'read_next').length ?? 0, [items])
+
+  return (
+    <>
+      <PageHeader
+        title={t('suggestions_page.title')}
+        description={t('suggestions_page.description')}
+        actions={
+          <button
+            type="button"
+            onClick={runNow}
+            disabled={running}
+            className="rounded-md border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+          >
+            {running ? t('suggestions_page.running') : t('suggestions_page.run_now')}
+          </button>
+        }
+      />
+      <div className="p-4 sm:p-6 space-y-4 max-w-screen-2xl mx-auto">
+        <div className="flex items-center gap-2">
+          <FilterTab active={filter === 'all'} onClick={() => setFilter('all')}>
+            {t('suggestions_page.filters.all', { count: items?.length ?? 0 })}
+          </FilterTab>
+          <FilterTab active={filter === 'read_next'} onClick={() => setFilter('read_next')}>
+            {t('suggestions_page.filters.read_next', { count: readNextCount })}
+          </FilterTab>
+          <FilterTab active={filter === 'buy'} onClick={() => setFilter('buy')}>
+            {t('suggestions_page.filters.buy', { count: buyCount })}
+          </FilterTab>
+        </div>
+
+        {error ? (
+          <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-4 text-sm text-red-700 dark:text-red-300">
+            {error}
+          </div>
+        ) : filtered === null ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+            {[...Array(6)].map((_, i) => (
+              <div key={i} className="space-y-2">
+                <div className="aspect-[2/3] rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                <div className="h-3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                <div className="h-2 w-2/3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+              </div>
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 p-8 text-center">
+            <p className="text-sm font-medium text-gray-900 dark:text-white">
+              {t('suggestions_page.empty.title')}
+            </p>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {t('suggestions_page.empty.hint')}
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-4">
+            {filtered.map(s => (
+              <SuggestionCard key={s.id} suggestion={s} onChanged={handleChanged} />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+function FilterTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? 'rounded-full bg-blue-600 text-white px-3 py-1.5 text-xs font-medium'
+          : 'rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:border-blue-300 dark:hover:border-blue-700 px-3 py-1.5 text-xs font-medium transition-colors'
+      }
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/pages/admin/ConnectionsLayout.tsx
+++ b/src/pages/admin/ConnectionsLayout.tsx
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { Outlet } from 'react-router-dom'
+
+export default function ConnectionsLayout() {
+  return (
+    <div className="h-full overflow-auto bg-gray-50 dark:bg-gray-950">
+      <Outlet />
+    </div>
+  )
+}

--- a/src/pages/admin/connections/AIPage.tsx
+++ b/src/pages/admin/connections/AIPage.tsx
@@ -1,0 +1,528 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useCallback, useEffect, useState } from 'react'
+import { useAuth, ApiError } from '../../../auth/AuthContext'
+import type { AIProviderStatus, AIPermissions, AIConfigField } from '../../../types'
+import PageHeader from '../../../components/PageHeader'
+import { usePageTitle } from '../../../hooks/usePageTitle'
+
+type TestState =
+  | { status: 'idle' }
+  | { status: 'testing' }
+  | { status: 'ok'; reply: string }
+  | { status: 'fail'; error: string }
+
+interface ProviderCardProps {
+  provider: AIProviderStatus
+  onSaved: (updated: AIProviderStatus[]) => void
+  onActivate: (name: string) => void
+  activating: boolean
+}
+
+function isSensitive(field: AIConfigField): boolean {
+  return field.type === 'password' || field.key === 'api_key'
+}
+
+// ProviderCard renders a single AI provider config card. Fields are driven by
+// the server-declared `config_fields` so Anthropic (api_key + model), OpenAI
+// (api_key + model), and Ollama (base_url + model) all render correctly
+// without client-side shape knowledge.
+function ProviderCard({ provider, onSaved, onActivate, activating }: ProviderCardProps) {
+  const { callApi } = useAuth()
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [enabled, setEnabled] = useState(provider.enabled)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+  const [testState, setTestState] = useState<TestState>({ status: 'idle' })
+
+  useEffect(() => {
+    setEnabled(provider.enabled)
+  }, [provider.enabled])
+
+  // Seed non-sensitive values from the server config on mount / provider change
+  // so the user sees their saved model ID / base URL and can edit in place.
+  useEffect(() => {
+    const next: Record<string, string> = {}
+    for (const f of provider.config_fields) {
+      if (!isSensitive(f)) next[f.key] = provider.config?.[f.key] ?? ''
+    }
+    setValues(next)
+  }, [provider])
+
+  const setValue = (key: string, v: string) => {
+    setValues(prev => ({ ...prev, [key]: v }))
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const body: Record<string, string> = { enabled: enabled ? 'true' : 'false' }
+      for (const f of provider.config_fields) {
+        const v = values[f.key] ?? ''
+        // Only send a sensitive field if the user typed something. Omitting
+        // preserves what's stored server-side (avoids clobbering saved keys).
+        if (isSensitive(f)) {
+          if (v) body[f.key] = v
+        } else {
+          body[f.key] = v
+        }
+      }
+      const updated = await callApi<AIProviderStatus[]>(
+        `/api/v1/admin/connections/ai/${provider.name}`,
+        { method: 'PUT', body: JSON.stringify(body) }
+      )
+      if (updated) {
+        onSaved(updated)
+        // Clear sensitive inputs so the "(saved)" indicator is the source of truth.
+        setValues(prev => {
+          const next = { ...prev }
+          for (const f of provider.config_fields) {
+            if (isSensitive(f)) next[f.key] = ''
+          }
+          return next
+        })
+        setSuccess(true)
+        setTimeout(() => setSuccess(false), 2000)
+      }
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleTest = async () => {
+    setTestState({ status: 'testing' })
+    try {
+      const res = await callApi<{ ok: boolean; reply?: string; error?: string }>(
+        `/api/v1/admin/connections/ai/${provider.name}/test`,
+        { method: 'POST' }
+      )
+      if (res?.ok) {
+        setTestState({ status: 'ok', reply: res.reply ?? '(no reply)' })
+      } else {
+        setTestState({ status: 'fail', error: res?.error ?? 'Unknown error' })
+      }
+    } catch (err) {
+      setTestState({ status: 'fail', error: err instanceof ApiError ? err.message : 'Request failed' })
+    }
+  }
+
+  const canToggleOn = !provider.config_fields.some(f => isSensitive(f) && f.required)
+    || provider.has_api_key
+    || Boolean(values['api_key'])
+
+  return (
+    <div className={`rounded-xl border bg-white dark:bg-gray-800 p-5 ${
+      provider.active
+        ? 'border-blue-500 ring-1 ring-blue-500/30 dark:border-blue-400'
+        : 'border-gray-200 dark:border-gray-700'
+    }`}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="font-semibold text-gray-900 dark:text-white">{provider.display_name}</h3>
+            {provider.active && (
+              <span className="inline-flex items-center rounded-full bg-blue-100 dark:bg-blue-900/40 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-300">
+                Active
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{provider.description}</p>
+        </div>
+        <label className="relative inline-flex items-center cursor-pointer shrink-0" title={
+          !canToggleOn ? 'Save an API key first' : ''
+        }>
+          <input
+            type="checkbox"
+            className="sr-only peer"
+            checked={enabled}
+            onChange={e => setEnabled(e.target.checked)}
+            disabled={!canToggleOn && !enabled}
+          />
+          <div className="w-10 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+        </label>
+      </div>
+
+      {provider.help_text && (
+        <div className="mt-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 px-3 py-2 text-sm text-blue-700 dark:text-blue-300">
+          {provider.help_text}
+          {provider.help_url && (
+            <> <a href={provider.help_url} target="_blank" rel="noopener noreferrer" className="font-medium underline hover:no-underline">Learn more →</a></>
+          )}
+        </div>
+      )}
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        {provider.config_fields.map(field => {
+          const sensitive = isSensitive(field)
+          const placeholder = sensitive && provider.has_api_key
+            ? '••••••••••••••••'
+            : field.placeholder ?? ''
+          return (
+            <div key={field.key} className={field.options?.length ? 'sm:col-span-2' : ''}>
+              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                {field.label}
+                {sensitive && provider.has_api_key && (
+                  <span className="ml-1 text-green-600 dark:text-green-400">(saved)</span>
+                )}
+                {field.required && !provider.has_api_key && sensitive && (
+                  <span className="ml-1 text-gray-400">*</span>
+                )}
+              </label>
+              {field.options && field.options.length > 0 ? (
+                <div className="flex gap-2">
+                  <select
+                    value={
+                      field.options.includes(values[field.key] ?? '')
+                        ? values[field.key] ?? ''
+                        : '__custom__'
+                    }
+                    onChange={e => {
+                      if (e.target.value === '__custom__') {
+                        setValue(field.key, '')
+                      } else {
+                        setValue(field.key, e.target.value)
+                      }
+                    }}
+                    className="rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  >
+                    {field.options.map(o => (
+                      <option key={o} value={o}>{o}</option>
+                    ))}
+                    <option value="__custom__">Custom…</option>
+                  </select>
+                  <input
+                    type="text"
+                    value={values[field.key] ?? ''}
+                    onChange={e => setValue(field.key, e.target.value)}
+                    placeholder={placeholder}
+                    className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  />
+                </div>
+              ) : (
+                <input
+                  type={sensitive ? 'password' : field.type === 'url' ? 'url' : 'text'}
+                  value={values[field.key] ?? ''}
+                  onChange={e => setValue(field.key, e.target.value)}
+                  placeholder={placeholder}
+                  className="w-full rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+              )}
+              {field.help_text && (
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{field.help_text}</p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="mt-4 space-y-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            type="button"
+            onClick={handleTest}
+            disabled={testState.status === 'testing' || !provider.enabled}
+            title={!provider.enabled ? 'Enable the provider first' : ''}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+          >
+            {testState.status === 'testing' ? 'Testing…' : 'Test'}
+          </button>
+          {!provider.active && provider.enabled && (
+            <button
+              type="button"
+              onClick={() => onActivate(provider.name)}
+              disabled={activating}
+              className="rounded-lg border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+            >
+              {activating ? 'Activating…' : 'Set active'}
+            </button>
+          )}
+          {success && <span className="text-sm text-green-600 dark:text-green-400">Saved</span>}
+          {error && <span className="text-sm text-red-600 dark:text-red-400">{error}</span>}
+        </div>
+        {testState.status === 'ok' && (
+          <div className="rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 px-3 py-2 text-sm text-green-700 dark:text-green-300">
+            Connected — reply: <span className="font-medium">{testState.reply}</span>
+          </div>
+        )}
+        {testState.status === 'fail' && (
+          <div className="rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+            {testState.error}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const PERMISSION_ITEMS: Array<{ key: keyof AIPermissions; label: string; description: string }> = [
+  {
+    key: 'reading_history',
+    label: 'Reading history',
+    description: "Titles the user has read or is currently reading.",
+  },
+  {
+    key: 'ratings',
+    label: 'Ratings',
+    description: 'Per-book star ratings and read status.',
+  },
+  {
+    key: 'favourites',
+    label: 'Favourites',
+    description: 'Books the user has marked as favourites.',
+  },
+  {
+    key: 'full_library',
+    label: 'Full library',
+    description: 'All books in the library, including unread candidates.',
+  },
+  {
+    key: 'taste_profile',
+    label: 'Taste profile',
+    description: 'Genre / theme / author preferences from the profile form.',
+  },
+]
+
+interface PermissionsCardProps {
+  permissions: AIPermissions
+  onSaved: (p: AIPermissions) => void
+}
+
+function PermissionsCard({ permissions, onSaved }: PermissionsCardProps) {
+  const { callApi } = useAuth()
+  const [local, setLocal] = useState<AIPermissions>(permissions)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    setLocal(permissions)
+  }, [permissions])
+
+  const dirty =
+    local.reading_history !== permissions.reading_history ||
+    local.ratings !== permissions.ratings ||
+    local.favourites !== permissions.favourites ||
+    local.full_library !== permissions.full_library ||
+    local.taste_profile !== permissions.taste_profile
+
+  const toggle = (k: keyof AIPermissions) => {
+    setLocal(prev => ({ ...prev, [k]: !prev[k] }))
+    setSuccess(false)
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    setSuccess(false)
+    try {
+      const updated = await callApi<AIPermissions>(
+        '/api/v1/admin/connections/ai/permissions',
+        { method: 'PUT', body: JSON.stringify(local) }
+      )
+      if (updated) {
+        onSaved(updated)
+        setSuccess(true)
+        setTimeout(() => setSuccess(false), 2000)
+      }
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to save permissions')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+      <h3 className="font-semibold text-gray-900 dark:text-white">Data-access permissions</h3>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        Controls which personal data the AI may see. Combined restrictively with each user's opt-in — if either
+        is off, that category is withheld.
+      </p>
+      <div className="mt-4 divide-y divide-gray-100 dark:divide-gray-700 border-t border-gray-100 dark:border-gray-700">
+        {PERMISSION_ITEMS.map(item => (
+          <div key={item.key} className="flex items-start justify-between gap-4 py-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">{item.label}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">{item.description}</p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer shrink-0 mt-0.5">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={local[item.key]}
+                onChange={() => toggle(item.key)}
+              />
+              <div className="w-10 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            </label>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+          className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {saving ? 'Saving…' : 'Save permissions'}
+        </button>
+        {success && <span className="text-sm text-green-600 dark:text-green-400">Saved</span>}
+        {error && <span className="text-sm text-red-600 dark:text-red-400">{error}</span>}
+      </div>
+    </div>
+  )
+}
+
+export default function AIPage() {
+  const { callApi } = useAuth()
+  const [providers, setProviders] = useState<AIProviderStatus[]>([])
+  const [permissions, setPermissions] = useState<AIPermissions>({
+    reading_history: false,
+    ratings: false,
+    favourites: false,
+    full_library: false,
+    taste_profile: false,
+  })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [activating, setActivating] = useState<string | null>(null)
+  usePageTitle('AI Connections')
+
+  const reloadProviders = useCallback(async () => {
+    try {
+      const ps = await callApi<AIProviderStatus[]>('/api/v1/admin/connections/ai')
+      setProviders(ps ?? [])
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load providers')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    Promise.all([
+      callApi<AIProviderStatus[]>('/api/v1/admin/connections/ai'),
+      callApi<AIPermissions>('/api/v1/admin/connections/ai/permissions'),
+    ])
+      .then(([ps, perms]) => {
+        setProviders(ps ?? [])
+        if (perms) setPermissions(perms)
+      })
+      .catch(err => setError(err instanceof ApiError ? err.message : 'Failed to load'))
+      .finally(() => setLoading(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleActivate = async (name: string) => {
+    setActivating(name)
+    try {
+      await callApi('/api/v1/admin/connections/ai/active', {
+        method: 'POST',
+        body: JSON.stringify({ provider: name }),
+      })
+      await reloadProviders()
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to set active provider')
+    } finally {
+      setActivating(null)
+    }
+  }
+
+  const handleDeactivate = async () => {
+    setActivating('__clear__')
+    try {
+      await callApi('/api/v1/admin/connections/ai/active', {
+        method: 'POST',
+        body: JSON.stringify({ provider: '' }),
+      })
+      await reloadProviders()
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to clear active provider')
+    } finally {
+      setActivating(null)
+    }
+  }
+
+  const active = providers.find(p => p.active)
+
+  return (
+    <>
+      <PageHeader
+        title="AI"
+        description="Configure AI providers for book suggestions. Only one provider is active at a time."
+        breadcrumbs={[{ label: 'Connections', to: '/admin/connections' }, { label: 'AI' }]}
+      />
+      <div className="max-w-3xl px-8 py-8 space-y-8">
+        {error && (
+          <div className="rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 text-sm text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20 text-gray-500 dark:text-gray-400">
+            Loading…
+          </div>
+        ) : (
+          <>
+            <section>
+              <div className="flex items-center justify-between mb-3">
+                <div>
+                  <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                    Providers
+                  </h2>
+                  <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                    {active
+                      ? <>Active: <span className="font-medium text-gray-700 dark:text-gray-300">{active.display_name}</span></>
+                      : 'No provider active — suggestions are disabled.'}
+                  </p>
+                </div>
+                {active && (
+                  <button
+                    type="button"
+                    onClick={handleDeactivate}
+                    disabled={activating !== null}
+                    className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+                  >
+                    Clear active
+                  </button>
+                )}
+              </div>
+              <div className="space-y-3">
+                {providers.map(p => (
+                  <ProviderCard
+                    key={p.name}
+                    provider={p}
+                    onSaved={setProviders}
+                    onActivate={handleActivate}
+                    activating={activating === p.name}
+                  />
+                ))}
+              </div>
+            </section>
+
+            <section>
+              <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                Permissions
+              </h2>
+              <PermissionsCard permissions={permissions} onSaved={setPermissions} />
+            </section>
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/pages/admin/connections/AIPage.tsx
+++ b/src/pages/admin/connections/AIPage.tsx
@@ -24,10 +24,302 @@ function isSensitive(field: AIConfigField): boolean {
   return field.type === 'password' || field.key === 'api_key'
 }
 
+// OllamaModel mirrors the subset of /api/tags we expose through the Go proxy
+// at /api/v1/admin/connections/ai/ollama/models. Size is bytes; parameter_size
+// and quantization are descriptive strings like "7B" / "Q4_K_M" when present.
+interface OllamaModel {
+  name: string
+  size: number
+  modified: string
+  digest: string
+  family?: string
+  parameter_size?: string
+  quantization?: string
+}
+
+function formatOllamaSize(bytes: number): string {
+  if (!bytes || bytes <= 0) return ''
+  const gb = bytes / 1_073_741_824
+  if (gb >= 1) return `${gb.toFixed(1)} GB`
+  const mb = bytes / 1_048_576
+  return `${mb.toFixed(0)} MB`
+}
+
+// OllamaModelPicker renders a dropdown populated from the Ollama host's
+// /api/tags (fetched via the Go proxy so the browser never talks to Ollama
+// directly). Falls back to a plain text input if the host is unreachable —
+// better to let the admin save a config they know is correct than to block
+// them on a transient network error.
+function OllamaModelPicker({
+  value,
+  onChange,
+  placeholder,
+  configuredBaseURL,
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+  configuredBaseURL: string
+}) {
+  const { callApi } = useAuth()
+  const [models, setModels] = useState<OllamaModel[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [customMode, setCustomMode] = useState(false)
+
+  const fetchModels = useCallback(async () => {
+    // No point fetching if the admin hasn't saved a base URL yet — the backend
+    // reads the stored config, not a parameter. Show the text input and wait.
+    if (!configuredBaseURL) {
+      setModels(null)
+      setError(null)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await callApi<{ models: OllamaModel[] }>(
+        '/api/v1/admin/connections/ai/ollama/models'
+      )
+      setModels(res?.models ?? [])
+    } catch (err) {
+      setModels(null)
+      setError(err instanceof ApiError ? err.message : "couldn't reach Ollama")
+    } finally {
+      setLoading(false)
+    }
+  }, [callApi, configuredBaseURL])
+
+  useEffect(() => {
+    fetchModels()
+  }, [fetchModels])
+
+  // Unreachable or not yet configured → plain text input. Keeps the admin
+  // unblocked: they can type a model name and save without the fetch working.
+  if (!models || customMode) {
+    return (
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        {models && (
+          <button
+            type="button"
+            onClick={() => setCustomMode(false)}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            title="Pick from installed models"
+          >
+            List
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={fetchModels}
+          disabled={loading || !configuredBaseURL}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+          title={configuredBaseURL ? 'Refresh model list' : 'Save a base URL first'}
+        >
+          {loading ? '…' : '↻'}
+        </button>
+        {error && !loading && (
+          <span className="self-center text-xs text-amber-600 dark:text-amber-400">{error}</span>
+        )}
+      </div>
+    )
+  }
+
+  const selectValue = models.some(m => m.name === value) ? value : ''
+
+  return (
+    <div className="flex gap-2">
+      <select
+        value={selectValue}
+        onChange={e => {
+          if (e.target.value === '__custom__') {
+            setCustomMode(true)
+            onChange('')
+          } else {
+            onChange(e.target.value)
+          }
+        }}
+        className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      >
+        {models.length === 0 ? (
+          <option value="">No models pulled — use `ollama pull` on the host</option>
+        ) : (
+          <>
+            {selectValue === '' && <option value="">Select a model…</option>}
+            {models.map(m => {
+              const meta = [m.parameter_size, m.quantization, formatOllamaSize(m.size)]
+                .filter(Boolean)
+                .join(' · ')
+              return (
+                <option key={m.digest} value={m.name}>
+                  {m.name}{meta ? ` — ${meta}` : ''}
+                </option>
+              )
+            })}
+          </>
+        )}
+        <option value="__custom__">Custom…</option>
+      </select>
+      <button
+        type="button"
+        onClick={fetchModels}
+        disabled={loading}
+        className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+        title="Refresh model list"
+      >
+        {loading ? '…' : '↻'}
+      </button>
+    </div>
+  )
+}
+
+// OsaurusModel mirrors the subset of /v1/models we expose through the Go proxy
+// at /api/v1/admin/connections/ai/osaurus/models. Osaurus returns OpenAI-shape
+// records, so we only get an id and (optionally) owned_by — no size / quant
+// metadata like Ollama provides.
+interface OsaurusModel {
+  id: string
+  owned_by?: string
+  created?: number
+}
+
+// OsaurusModelPicker mirrors OllamaModelPicker against the Osaurus server's
+// /v1/models endpoint. Separate component because the data shape and "no
+// models available" messaging differ — Osaurus models are pulled via the
+// desktop app, not a CLI.
+function OsaurusModelPicker({
+  value,
+  onChange,
+  placeholder,
+  configuredBaseURL,
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+  configuredBaseURL: string
+}) {
+  const { callApi } = useAuth()
+  const [models, setModels] = useState<OsaurusModel[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [customMode, setCustomMode] = useState(false)
+
+  const fetchModels = useCallback(async () => {
+    if (!configuredBaseURL) {
+      setModels(null)
+      setError(null)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await callApi<{ models: OsaurusModel[] }>(
+        '/api/v1/admin/connections/ai/osaurus/models'
+      )
+      setModels(res?.models ?? [])
+    } catch (err) {
+      setModels(null)
+      setError(err instanceof ApiError ? err.message : "couldn't reach Osaurus")
+    } finally {
+      setLoading(false)
+    }
+  }, [callApi, configuredBaseURL])
+
+  useEffect(() => {
+    fetchModels()
+  }, [fetchModels])
+
+  if (!models || customMode) {
+    return (
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+        {models && (
+          <button
+            type="button"
+            onClick={() => setCustomMode(false)}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            title="Pick from installed models"
+          >
+            List
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={fetchModels}
+          disabled={loading || !configuredBaseURL}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+          title={configuredBaseURL ? 'Refresh model list' : 'Save a base URL first'}
+        >
+          {loading ? '…' : '↻'}
+        </button>
+        {error && !loading && (
+          <span className="self-center text-xs text-amber-600 dark:text-amber-400">{error}</span>
+        )}
+      </div>
+    )
+  }
+
+  const selectValue = models.some(m => m.id === value) ? value : ''
+
+  return (
+    <div className="flex gap-2">
+      <select
+        value={selectValue}
+        onChange={e => {
+          if (e.target.value === '__custom__') {
+            setCustomMode(true)
+            onChange('')
+          } else {
+            onChange(e.target.value)
+          }
+        }}
+        className="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      >
+        {models.length === 0 ? (
+          <option value="">No models downloaded — download one in the Osaurus app</option>
+        ) : (
+          <>
+            {selectValue === '' && <option value="">Select a model…</option>}
+            {models.map(m => (
+              <option key={m.id} value={m.id}>
+                {m.id}{m.owned_by ? ` — ${m.owned_by}` : ''}
+              </option>
+            ))}
+          </>
+        )}
+        <option value="__custom__">Custom…</option>
+      </select>
+      <button
+        type="button"
+        onClick={fetchModels}
+        disabled={loading}
+        className="rounded-lg border border-gray-300 dark:border-gray-600 px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+        title="Refresh model list"
+      >
+        {loading ? '…' : '↻'}
+      </button>
+    </div>
+  )
+}
+
 // ProviderCard renders a single AI provider config card. Fields are driven by
 // the server-declared `config_fields` so Anthropic (api_key + model), OpenAI
-// (api_key + model), and Ollama (base_url + model) all render correctly
-// without client-side shape knowledge.
+// (api_key + model), Ollama (base_url + model), and Osaurus (base_url +
+// model + optional api_key) all render correctly without client-side shape
+// knowledge.
 function ProviderCard({ provider, onSaved, onActivate, activating }: ProviderCardProps) {
   const { callApi } = useAuth()
   const [values, setValues] = useState<Record<string, string>>({})
@@ -163,8 +455,10 @@ function ProviderCard({ provider, onSaved, onActivate, activating }: ProviderCar
           const placeholder = sensitive && provider.has_api_key
             ? '••••••••••••••••'
             : field.placeholder ?? ''
+          const isOllamaModel = provider.name === 'ollama' && field.key === 'model'
+          const isOsaurusModel = provider.name === 'osaurus' && field.key === 'model'
           return (
-            <div key={field.key} className={field.options?.length ? 'sm:col-span-2' : ''}>
+            <div key={field.key} className={(field.options?.length || isOllamaModel || isOsaurusModel) ? 'sm:col-span-2' : ''}>
               <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
                 {field.label}
                 {sensitive && provider.has_api_key && (
@@ -174,7 +468,21 @@ function ProviderCard({ provider, onSaved, onActivate, activating }: ProviderCar
                   <span className="ml-1 text-gray-400">*</span>
                 )}
               </label>
-              {field.options && field.options.length > 0 ? (
+              {isOllamaModel ? (
+                <OllamaModelPicker
+                  value={values[field.key] ?? ''}
+                  onChange={v => setValue(field.key, v)}
+                  placeholder={placeholder}
+                  configuredBaseURL={provider.config?.base_url ?? ''}
+                />
+              ) : isOsaurusModel ? (
+                <OsaurusModelPicker
+                  value={values[field.key] ?? ''}
+                  onChange={v => setValue(field.key, v)}
+                  placeholder={placeholder}
+                  configuredBaseURL={provider.config?.base_url ?? ''}
+                />
+              ) : field.options && field.options.length > 0 ? (
                 <div className="flex gap-2">
                   <select
                     value={

--- a/src/pages/jobs/AISuggestionsJobCard.tsx
+++ b/src/pages/jobs/AISuggestionsJobCard.tsx
@@ -302,15 +302,27 @@ export default function AISuggestionsJobCard({ onRunKicked }: AISuggestionsJobCa
           <div>
             <label className="block text-sm font-medium text-gray-900 dark:text-white">User run rate limit (per day)</label>
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              Maximum number of user-triggered "Run now" requests allowed per user in 24 hours. 0 disables user-triggered runs.
+              Maximum number of user-triggered "Run now" requests allowed per user in 24 hours. Check "Unlimited" for local providers like Ollama or Osaurus; <code>0</code> disables user-triggered runs entirely.
             </p>
-            <input
-              type="number"
-              min={0}
-              value={config.user_run_rate_limit_per_day}
-              onChange={e => set('user_run_rate_limit_per_day', Math.max(0, Number(e.target.value)))}
-              className="mt-1 w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
-            />
+            <div className="mt-1 flex items-center gap-3">
+              <input
+                type="number"
+                min={0}
+                value={config.user_run_rate_limit_per_day < 0 ? '' : config.user_run_rate_limit_per_day}
+                disabled={config.user_run_rate_limit_per_day < 0}
+                onChange={e => set('user_run_rate_limit_per_day', Math.max(0, Number(e.target.value)))}
+                className="w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              />
+              <label className="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={config.user_run_rate_limit_per_day < 0}
+                  onChange={e => set('user_run_rate_limit_per_day', e.target.checked ? -1 : 1)}
+                  className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500"
+                />
+                Unlimited
+              </label>
+            </div>
           </div>
 
           <div className="flex items-center gap-3 pt-2">

--- a/src/pages/jobs/AISuggestionsJobCard.tsx
+++ b/src/pages/jobs/AISuggestionsJobCard.tsx
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 fireball1725
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import { useToast } from '../../components/Toast'
-import type { AISuggestionsJobConfig } from '../../types'
+import RunDetailPanel, { RunSummary } from '../../components/RunDetailPanel'
+import type { AISuggestionsJobConfig, SuggestionRunView } from '../../types'
 
 // INTERVAL_PRESETS are friendly labels over minute counts. Custom values stay
 // editable in the raw input so admins can pick anything.
@@ -37,6 +38,8 @@ export default function AISuggestionsJobCard() {
   const [running, setRunning] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
+  const [runs, setRuns] = useState<SuggestionRunView[] | null>(null)
+  const [expandedRunId, setExpandedRunId] = useState<string | null>(null)
 
   useEffect(() => {
     callApi<AISuggestionsJobConfig>('/api/v1/admin/jobs/ai-suggestions')
@@ -50,6 +53,27 @@ export default function AISuggestionsJobCard() {
       .finally(() => setLoading(false))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  const loadRuns = useMemo(
+    () => () => {
+      callApi<SuggestionRunView[]>('/api/v1/admin/jobs/ai-suggestions/runs')
+        .then(data => setRuns(data ?? []))
+        .catch(() => setRuns([]))
+    },
+    [callApi]
+  )
+
+  useEffect(() => {
+    if (expanded) loadRuns()
+  }, [expanded, loadRuns])
+
+  // Poll while any run is in progress so status updates without manual refresh.
+  const hasRunning = useMemo(() => (runs ?? []).some(r => r.status === 'running'), [runs])
+  useEffect(() => {
+    if (!expanded || !hasRunning) return
+    const id = setInterval(loadRuns, 3000)
+    return () => clearInterval(id)
+  }, [expanded, hasRunning, loadRuns])
 
   const dirty = config !== null && initial !== null && JSON.stringify(config) !== JSON.stringify(initial)
 
@@ -92,6 +116,9 @@ export default function AISuggestionsJobCard() {
           : 'Enqueued suggestions run',
         { variant: 'success' }
       )
+      // Refresh the runs list so the newly-queued run appears right away;
+      // the polling effect will flip it from running → completed in the background.
+      loadRuns()
     } catch (err) {
       showToast(err instanceof ApiError ? err.message : 'Failed to enqueue run', { variant: 'error' })
     } finally {
@@ -284,6 +311,49 @@ export default function AISuggestionsJobCard() {
               {saving ? 'Saving…' : 'Save config'}
             </button>
             {error && <span className="text-sm text-red-600 dark:text-red-400">{error}</span>}
+          </div>
+
+          {/* Recent runs */}
+          <div className="pt-4 border-t border-gray-100 dark:border-gray-800">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">Recent runs</p>
+              <button
+                type="button"
+                onClick={loadRuns}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Refresh
+              </button>
+            </div>
+            {runs === null ? (
+              <p className="text-xs text-gray-500 dark:text-gray-400">Loading runs…</p>
+            ) : runs.length === 0 ? (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                No runs yet. Click "Run now" above to enqueue one for every opted-in user.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {runs.slice(0, 10).map(run => (
+                  <li key={run.id}>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedRunId(prev => (prev === run.id ? null : run.id))}
+                      className="w-full text-left"
+                    >
+                      <RunSummary run={run} />
+                    </button>
+                    {expandedRunId === run.id && (
+                      <div className="mt-2">
+                        <RunDetailPanel
+                          endpoint={`/api/v1/admin/jobs/ai-suggestions/runs/${run.id}`}
+                          hideSummary
+                        />
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
       )}

--- a/src/pages/jobs/AISuggestionsJobCard.tsx
+++ b/src/pages/jobs/AISuggestionsJobCard.tsx
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useState } from 'react'
+import { useAuth, ApiError } from '../../auth/AuthContext'
+import { useToast } from '../../components/Toast'
+import type { AISuggestionsJobConfig } from '../../types'
+
+// INTERVAL_PRESETS are friendly labels over minute counts. Custom values stay
+// editable in the raw input so admins can pick anything.
+const INTERVAL_PRESETS: Array<{ minutes: number; label: string }> = [
+  { minutes: 60,       label: 'Every hour' },
+  { minutes: 6 * 60,   label: 'Every 6 hours' },
+  { minutes: 12 * 60,  label: 'Every 12 hours' },
+  { minutes: 24 * 60,  label: 'Daily' },
+  { minutes: 3 * 24 * 60, label: 'Every 3 days' },
+  { minutes: 7 * 24 * 60, label: 'Weekly' },
+]
+
+function formatInterval(minutes: number): string {
+  const p = INTERVAL_PRESETS.find(x => x.minutes === minutes)
+  if (p) return p.label
+  if (minutes <= 0) return 'Disabled'
+  const h = minutes / 60
+  if (h % 24 === 0 && h > 0) return `Every ${h / 24} day${h / 24 === 1 ? '' : 's'}`
+  if (minutes % 60 === 0) return `Every ${h} hour${h === 1 ? '' : 's'}`
+  return `Every ${minutes} minutes`
+}
+
+export default function AISuggestionsJobCard() {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const [config, setConfig] = useState<AISuggestionsJobConfig | null>(null)
+  const [initial, setInitial] = useState<AISuggestionsJobConfig | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState(false)
+
+  useEffect(() => {
+    callApi<AISuggestionsJobConfig>('/api/v1/admin/jobs/ai-suggestions')
+      .then(cfg => {
+        if (cfg) {
+          setConfig(cfg)
+          setInitial(cfg)
+        }
+      })
+      .catch(err => setError(err instanceof ApiError ? err.message : 'Failed to load job config'))
+      .finally(() => setLoading(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const dirty = config !== null && initial !== null && JSON.stringify(config) !== JSON.stringify(initial)
+
+  const set = <K extends keyof AISuggestionsJobConfig>(key: K, value: AISuggestionsJobConfig[K]) => {
+    setConfig(prev => (prev ? { ...prev, [key]: value } : prev))
+  }
+
+  const handleSave = async () => {
+    if (!config) return
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await callApi<AISuggestionsJobConfig>('/api/v1/admin/jobs/ai-suggestions', {
+        method: 'PUT',
+        body: JSON.stringify(config),
+      })
+      if (updated) {
+        setConfig(updated)
+        setInitial(updated)
+        showToast('Job config saved', { variant: 'success' })
+      }
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Failed to save'
+      setError(msg)
+      showToast(msg, { variant: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleRunNow = async () => {
+    setRunning(true)
+    try {
+      const res = await callApi<{ enqueued: number }>('/api/v1/admin/jobs/ai-suggestions/run', {
+        method: 'POST',
+      })
+      showToast(
+        res && typeof res.enqueued === 'number'
+          ? `Enqueued suggestions for ${res.enqueued} user${res.enqueued === 1 ? '' : 's'}`
+          : 'Enqueued suggestions run',
+        { variant: 'success' }
+      )
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to enqueue run', { variant: 'error' })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-900 px-5 py-4 text-sm text-gray-500 dark:text-gray-400">
+        Loading job config…
+      </div>
+    )
+  }
+
+  if (!config) {
+    return (
+      <div className="border border-gray-200 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-900 px-5 py-4 text-sm text-red-600 dark:text-red-400">
+        {error ?? 'Failed to load job config.'}
+      </div>
+    )
+  }
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden bg-white dark:bg-gray-900">
+      <button
+        type="button"
+        onClick={() => setExpanded(e => !e)}
+        className="w-full text-left px-5 py-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+      >
+        <div className="flex items-center gap-4">
+          <svg
+            className={`w-4 h-4 text-gray-400 flex-shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-gray-900 dark:text-white">AI suggestions</span>
+              <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                config.enabled
+                  ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300'
+                  : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'
+              }`}>
+                {config.enabled ? 'Enabled' : 'Disabled'}
+              </span>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Generates per-user book suggestions using the active AI provider. {formatInterval(config.interval_minutes)}.
+            </p>
+          </div>
+          <div onClick={e => e.stopPropagation()}>
+            <button
+              type="button"
+              onClick={handleRunNow}
+              disabled={running}
+              className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+            >
+              {running ? 'Running…' : 'Run now'}
+            </button>
+          </div>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50 px-5 py-5 space-y-4">
+          {/* Enabled */}
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">Enabled</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Master switch. When off, the scheduler won't enqueue any runs.
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer shrink-0 mt-0.5">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={config.enabled}
+                onChange={e => set('enabled', e.target.checked)}
+              />
+              <div className="w-10 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            </label>
+          </div>
+
+          {/* Cadence */}
+          <div>
+            <label className="block text-sm font-medium text-gray-900 dark:text-white">Cadence</label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              How often the scheduler should enqueue a run for each opted-in user.
+            </p>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <select
+                value={
+                  INTERVAL_PRESETS.some(p => p.minutes === config.interval_minutes)
+                    ? String(config.interval_minutes)
+                    : '__custom__'
+                }
+                onChange={e => {
+                  if (e.target.value !== '__custom__') {
+                    set('interval_minutes', Number(e.target.value))
+                  }
+                }}
+                className="rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                {INTERVAL_PRESETS.map(p => (
+                  <option key={p.minutes} value={p.minutes}>{p.label}</option>
+                ))}
+                <option value="__custom__">Custom…</option>
+              </select>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={0}
+                  value={config.interval_minutes}
+                  onChange={e => set('interval_minutes', Math.max(0, Number(e.target.value)))}
+                  className="w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+                <span className="text-xs text-gray-500 dark:text-gray-400">minutes</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Per-user caps */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-gray-900 dark:text-white">Max buy suggestions / run</label>
+              <input
+                type="number"
+                min={0}
+                value={config.max_buy_per_user}
+                onChange={e => set('max_buy_per_user', Math.max(0, Number(e.target.value)))}
+                className="mt-1 w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-900 dark:text-white">Max read-next suggestions / run</label>
+              <input
+                type="number"
+                min={0}
+                value={config.max_read_next_per_user}
+                onChange={e => set('max_read_next_per_user', Math.max(0, Number(e.target.value)))}
+                className="mt-1 w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          {/* Include taste profile */}
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">Include taste profile in prompt</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Still gated by each user's opt-in and the deployment permission toggle.
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer shrink-0 mt-0.5">
+              <input
+                type="checkbox"
+                className="sr-only peer"
+                checked={config.include_taste_profile}
+                onChange={e => set('include_taste_profile', e.target.checked)}
+              />
+              <div className="w-10 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+            </label>
+          </div>
+
+          {/* User run rate limit */}
+          <div>
+            <label className="block text-sm font-medium text-gray-900 dark:text-white">User run rate limit (per day)</label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Maximum number of user-triggered "Run now" requests allowed per user in 24 hours. 0 disables user-triggered runs.
+            </p>
+            <input
+              type="number"
+              min={0}
+              value={config.user_run_rate_limit_per_day}
+              onChange={e => set('user_run_rate_limit_per_day', Math.max(0, Number(e.target.value)))}
+              className="mt-1 w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || !dirty}
+              className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {saving ? 'Saving…' : 'Save config'}
+            </button>
+            {error && <span className="text-sm text-red-600 dark:text-red-400">{error}</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/jobs/AISuggestionsJobCard.tsx
+++ b/src/pages/jobs/AISuggestionsJobCard.tsx
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 fireball1725
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import { useToast } from '../../components/Toast'
-import RunDetailPanel, { RunSummary } from '../../components/RunDetailPanel'
-import type { AISuggestionsJobConfig, SuggestionRunView } from '../../types'
+import type { AISuggestionsJobConfig } from '../../types'
 
 // INTERVAL_PRESETS are friendly labels over minute counts. Custom values stay
 // editable in the raw input so admins can pick anything.
@@ -38,8 +37,6 @@ export default function AISuggestionsJobCard() {
   const [running, setRunning] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
-  const [runs, setRuns] = useState<SuggestionRunView[] | null>(null)
-  const [expandedRunId, setExpandedRunId] = useState<string | null>(null)
 
   useEffect(() => {
     callApi<AISuggestionsJobConfig>('/api/v1/admin/jobs/ai-suggestions')
@@ -53,27 +50,6 @@ export default function AISuggestionsJobCard() {
       .finally(() => setLoading(false))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
-  const loadRuns = useMemo(
-    () => () => {
-      callApi<SuggestionRunView[]>('/api/v1/admin/jobs/ai-suggestions/runs')
-        .then(data => setRuns(data ?? []))
-        .catch(() => setRuns([]))
-    },
-    [callApi]
-  )
-
-  useEffect(() => {
-    if (expanded) loadRuns()
-  }, [expanded, loadRuns])
-
-  // Poll while any run is in progress so status updates without manual refresh.
-  const hasRunning = useMemo(() => (runs ?? []).some(r => r.status === 'running'), [runs])
-  useEffect(() => {
-    if (!expanded || !hasRunning) return
-    const id = setInterval(loadRuns, 3000)
-    return () => clearInterval(id)
-  }, [expanded, hasRunning, loadRuns])
 
   const dirty = config !== null && initial !== null && JSON.stringify(config) !== JSON.stringify(initial)
 
@@ -116,9 +92,7 @@ export default function AISuggestionsJobCard() {
           : 'Enqueued suggestions run',
         { variant: 'success' }
       )
-      // Refresh the runs list so the newly-queued run appears right away;
-      // the polling effect will flip it from running → completed in the background.
-      loadRuns()
+      // The run appears in the History section below; JobsPage polls it.
     } catch (err) {
       showToast(err instanceof ApiError ? err.message : 'Failed to enqueue run', { variant: 'error' })
     } finally {
@@ -311,49 +285,6 @@ export default function AISuggestionsJobCard() {
               {saving ? 'Saving…' : 'Save config'}
             </button>
             {error && <span className="text-sm text-red-600 dark:text-red-400">{error}</span>}
-          </div>
-
-          {/* Recent runs */}
-          <div className="pt-4 border-t border-gray-100 dark:border-gray-800">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-medium text-gray-900 dark:text-white">Recent runs</p>
-              <button
-                type="button"
-                onClick={loadRuns}
-                className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                Refresh
-              </button>
-            </div>
-            {runs === null ? (
-              <p className="text-xs text-gray-500 dark:text-gray-400">Loading runs…</p>
-            ) : runs.length === 0 ? (
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                No runs yet. Click "Run now" above to enqueue one for every opted-in user.
-              </p>
-            ) : (
-              <ul className="space-y-2">
-                {runs.slice(0, 10).map(run => (
-                  <li key={run.id}>
-                    <button
-                      type="button"
-                      onClick={() => setExpandedRunId(prev => (prev === run.id ? null : run.id))}
-                      className="w-full text-left"
-                    >
-                      <RunSummary run={run} />
-                    </button>
-                    {expandedRunId === run.id && (
-                      <div className="mt-2">
-                        <RunDetailPanel
-                          endpoint={`/api/v1/admin/jobs/ai-suggestions/runs/${run.id}`}
-                          hideSummary
-                        />
-                      </div>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
           </div>
         </div>
       )}

--- a/src/pages/jobs/AISuggestionsJobCard.tsx
+++ b/src/pages/jobs/AISuggestionsJobCard.tsx
@@ -27,7 +27,13 @@ function formatInterval(minutes: number): string {
   return `Every ${minutes} minutes`
 }
 
-export default function AISuggestionsJobCard() {
+interface AISuggestionsJobCardProps {
+  // Fires after a successful Run now so the parent can reload the jobs list
+  // and surface the new run immediately.
+  onRunKicked?: () => void
+}
+
+export default function AISuggestionsJobCard({ onRunKicked }: AISuggestionsJobCardProps = {}) {
   const { callApi } = useAuth()
   const { show: showToast } = useToast()
   const [config, setConfig] = useState<AISuggestionsJobConfig | null>(null)
@@ -92,7 +98,9 @@ export default function AISuggestionsJobCard() {
           : 'Enqueued suggestions run',
         { variant: 'success' }
       )
-      // The run appears in the History section below; JobsPage polls it.
+      // Ask the parent to refresh its jobs list so the new run appears
+      // without the admin needing to reload the page.
+      onRunKicked?.()
     } catch (err) {
       showToast(err instanceof ApiError ? err.message : 'Failed to enqueue run', { variant: 'error' })
     } finally {
@@ -258,6 +266,36 @@ export default function AISuggestionsJobCard() {
               />
               <div className="w-10 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
             </label>
+          </div>
+
+          {/* Max tokens */}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-gray-900 dark:text-white">Max tokens (initial pass)</label>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Output-token cap for the first suggestion request. Thinking models (qwen3, deepseek-r1, extended-thinking Claude) need a higher cap — 6000 is a reasonable starting point.
+              </p>
+              <input
+                type="number"
+                min={0}
+                value={config.max_tokens_initial}
+                onChange={e => set('max_tokens_initial', Math.max(0, Number(e.target.value)))}
+                className="mt-1 w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-900 dark:text-white">Max tokens (backfill)</label>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Cap for each backfill retry when the first pass didn't fill every slot. Smaller is fine because backfill only asks for what's missing.
+              </p>
+              <input
+                type="number"
+                min={0}
+                value={config.max_tokens_backfill}
+                onChange={e => set('max_tokens_backfill', Math.max(0, Number(e.target.value)))}
+                className="mt-1 w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
           </div>
 
           {/* User run rate limit */}

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -5,12 +5,14 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import PageHeader from '../../components/PageHeader'
+import RunDetailPanel from '../../components/RunDetailPanel'
 import { usePageTitle } from '../../hooks/usePageTitle'
+import type { SuggestionRunView } from '../../types'
 import AISuggestionsJobCard from './AISuggestionsJobCard'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type JobType = 'import' | 'metadata' | 'cover'
+type JobType = 'import' | 'metadata' | 'cover' | 'ai_suggestions'
 type JobStatus = 'pending' | 'processing' | 'done' | 'failed' | 'cancelled'
 
 interface ImportItem {
@@ -45,6 +47,16 @@ interface Job {
   created_at: string
   updated_at: string
   items?: ImportItem[]
+  // AI-suggestion-run-only fields (undefined for imports/enrichment)
+  triggered_by?: string
+  provider_type?: string
+  model_id?: string
+  tokens_in?: number
+  tokens_out?: number
+  estimated_cost_usd?: number
+  user_id?: string
+  run_error?: string
+  finished_at?: string
 }
 
 // Raw shape returned by the enrichment-batches endpoint
@@ -78,13 +90,46 @@ function batchToJob(b: EnrichmentBatchRaw): Job {
   }
 }
 
+// runToJob folds a suggestion run into the Job shape so it sits alongside
+// imports and enrichment batches in the unified history list.
+function runToJob(r: SuggestionRunView): Job {
+  const status: JobStatus =
+    r.status === 'running' ? 'processing'
+      : r.status === 'completed' ? 'done'
+      : r.status === 'failed' ? 'failed'
+      : 'pending'
+  return {
+    id: r.id,
+    type: 'ai_suggestions',
+    library_id: '',
+    library_name: 'AI suggestions',
+    status,
+    total_rows: 0,
+    processed_rows: 0,
+    failed_rows: 0,
+    skipped_rows: 0,
+    created_at: r.started_at,
+    updated_at: r.finished_at ?? r.started_at,
+    triggered_by: r.triggered_by,
+    provider_type: r.provider_type,
+    model_id: r.model_id,
+    tokens_in: r.tokens_in,
+    tokens_out: r.tokens_out,
+    estimated_cost_usd: r.estimated_cost_usd,
+    user_id: r.user_id,
+    run_error: r.error,
+    finished_at: r.finished_at,
+  }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function TypeBadge({ type }: { type: JobType }) {
   const cfg: Record<JobType, { label: string; cls: string }> = {
-    import:   { label: 'Import',    cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
-    metadata: { label: 'Metadata',  cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
-    cover:    { label: 'Covers',    cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
+    import:         { label: 'Import',      cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
+    metadata:       { label: 'Metadata',    cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
+    cover:          { label: 'Covers',      cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
+    ai_suggestions: { label: 'Suggestions', cls: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' },
   }
   const { label, cls } = cfg[type] ?? cfg.import
   return (
@@ -92,6 +137,21 @@ function TypeBadge({ type }: { type: JobType }) {
       {label}
     </span>
   )
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n)
+  return `${(n / 1000).toFixed(1)}k`
+}
+
+function formatDurationSec(startIso: string, endIso?: string): string | null {
+  if (!endIso) return null
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime()
+  if (!Number.isFinite(ms) || ms < 0) return null
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const m = Math.floor(ms / 60_000)
+  const s = Math.round((ms % 60_000) / 1000)
+  return `${m}m${s.toString().padStart(2, '0')}s`
 }
 
 function StatusBadge({ status }: { status: JobStatus }) {
@@ -146,8 +206,11 @@ function JobRow({
   const [cancelling, setCancelling] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
-  const canCancel   = job.status === 'pending' || job.status === 'processing'
-  const canDelete   = job.status === 'done' || job.status === 'failed' || job.status === 'cancelled'
+  const isAISuggestions = job.type === 'ai_suggestions'
+  // No cancel/delete endpoints exist for suggestion runs yet, so hide the
+  // actions entirely for that type.
+  const canCancel   = !isAISuggestions && (job.status === 'pending' || job.status === 'processing')
+  const canDelete   = !isAISuggestions && (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled')
   const isActive    = job.status === 'pending' || job.status === 'processing'
   const isEnrichment = job.type === 'metadata' || job.type === 'cover'
 
@@ -166,7 +229,9 @@ function JobRow({
 
   const toggleExpand = async () => {
     const isEnr = job.type === 'metadata' || job.type === 'cover'
-    if (!expanded) {
+    // AI suggestion runs expand into a RunDetailPanel, which self-fetches —
+    // skip the items lookup for that type.
+    if (!expanded && !isAISuggestions) {
       setLoadingItems(true)
       try {
         if (isEnr) {
@@ -243,13 +308,47 @@ function JobRow({
             <div className="min-w-0">
               <div className="flex items-center gap-2 mb-0.5">
                 <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                  {job.library_name ?? job.library_id}
+                  {isAISuggestions
+                    ? `Triggered by ${job.triggered_by ?? 'scheduler'}${job.user_id ? ` · user ${job.user_id.slice(0, 8)}` : ''}`
+                    : (job.library_name ?? job.library_id)}
                 </span>
                 <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
                   {job.id.slice(0, 8)}
                 </span>
               </div>
-              {isActive ? (
+              {isAISuggestions ? (
+                isActive ? (
+                  <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                    <span className="inline-block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                    <span>Running…</span>
+                    {job.provider_type && (
+                      <span className="text-gray-400">{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {job.provider_type && (
+                      <span>{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
+                    )}
+                    {(job.tokens_in !== undefined || job.tokens_out !== undefined) && (
+                      <span className="tabular-nums">
+                        {formatTokens(job.tokens_in ?? 0)} in / {formatTokens(job.tokens_out ?? 0)} out
+                      </span>
+                    )}
+                    {job.estimated_cost_usd !== undefined && job.estimated_cost_usd > 0 && (
+                      <span className="tabular-nums">${job.estimated_cost_usd.toFixed(4)}</span>
+                    )}
+                    {formatDurationSec(job.created_at, job.finished_at) && (
+                      <span className="tabular-nums">{formatDurationSec(job.created_at, job.finished_at)}</span>
+                    )}
+                    {job.run_error && (
+                      <span className="text-red-600 dark:text-red-400 truncate max-w-xs" title={job.run_error}>
+                        {job.run_error}
+                      </span>
+                    )}
+                  </div>
+                )
+              ) : isActive ? (
                 <div className="flex items-center gap-2">
                   <div className="flex-1 h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden max-w-xs">
                     <div
@@ -307,7 +406,14 @@ function JobRow({
 
       {expanded && (
         <div className="border-t border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
-          {loadingItems ? (
+          {isAISuggestions ? (
+            <div className="px-5 py-4">
+              <RunDetailPanel
+                endpoint={`/api/v1/admin/jobs/ai-suggestions/runs/${job.id}`}
+                hideSummary
+              />
+            </div>
+          ) : loadingItems ? (
             <div className="flex items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
               <div className="w-4 h-4 rounded-full border-2 border-blue-500 border-t-transparent animate-spin mr-2" />
               Loading…
@@ -404,14 +510,18 @@ export default function JobsPage() {
 
   const loadJobs = async () => {
     try {
-      const [importData, batchData] = await Promise.all([
+      const [importData, batchData, runData] = await Promise.all([
         callApi<Job[]>('/api/v1/imports'),
         callApi<EnrichmentBatchRaw[]>('/api/v1/enrichment-batches'),
+        // Suggestion runs are admin-only — tolerate failure so non-admins
+        // (if they ever reach this page) still see imports/enrichment.
+        callApi<SuggestionRunView[]>('/api/v1/admin/jobs/ai-suggestions/runs').catch(() => []),
       ])
       const imports = (importData ?? []).map(j => ({ ...j, type: 'import' as JobType }))
       const batches = (batchData ?? []).map(batchToJob)
+      const runs = (runData ?? []).map(runToJob)
       // Merge and sort newest-first
-      const merged = [...imports, ...batches].sort(
+      const merged = [...imports, ...batches, ...runs].sort(
         (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
       )
       setJobs(merged)

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -207,9 +207,9 @@ function JobRow({
   const [deleting, setDeleting] = useState(false)
 
   const isAISuggestions = job.type === 'ai_suggestions'
-  // No cancel/delete endpoints exist for suggestion runs yet, so hide the
-  // actions entirely for that type.
-  const canCancel   = !isAISuggestions && (job.status === 'pending' || job.status === 'processing')
+  // AI suggestion runs support cancel (admin only) but not delete; enrichment
+  // and import jobs support both.
+  const canCancel   = job.status === 'pending' || job.status === 'processing'
   const canDelete   = !isAISuggestions && (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled')
   const isActive    = job.status === 'pending' || job.status === 'processing'
   const isEnrichment = job.type === 'metadata' || job.type === 'cover'
@@ -256,10 +256,13 @@ function JobRow({
     if (!canCancel || cancelling) return
     setCancelling(true)
     try {
-      const path = isEnrichment
-        ? `/api/v1/enrichment-batches/${job.id}/cancel`
-        : `/api/v1/imports/${job.id}/cancel`
-      await callApi(path, { method: 'POST' })
+      if (isAISuggestions) {
+        await callApi(`/api/v1/admin/jobs/ai-suggestions/runs/${job.id}`, { method: 'DELETE' })
+      } else if (isEnrichment) {
+        await callApi(`/api/v1/enrichment-batches/${job.id}/cancel`, { method: 'POST' })
+      } else {
+        await callApi(`/api/v1/imports/${job.id}/cancel`, { method: 'POST' })
+      }
       onCancelled(job.id)
     } catch {
       // non-fatal — parent will refresh

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import PageHeader from '../../components/PageHeader'
 import { usePageTitle } from '../../hooks/usePageTitle'
+import AISuggestionsJobCard from './AISuggestionsJobCard'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -496,6 +497,17 @@ export default function JobsPage() {
           {error}
         </div>
       )}
+
+      <section className="mb-8">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+          Scheduled jobs
+        </h2>
+        <AISuggestionsJobCard />
+      </section>
+
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+        History
+      </h2>
 
       {jobs.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 p-12 text-center">

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -617,7 +617,7 @@ export default function JobsPage() {
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
           Scheduled jobs
         </h2>
-        <AISuggestionsJobCard />
+        <AISuggestionsJobCard onRunKicked={loadJobs} />
       </section>
 
       <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -569,6 +569,7 @@ export default function JobsPage() {
       await Promise.all([
         callApi('/api/v1/imports', { method: 'DELETE' }),
         callApi('/api/v1/enrichment-batches', { method: 'DELETE' }),
+        callApi('/api/v1/admin/jobs/ai-suggestions/runs', { method: 'DELETE' }).catch(() => {}),
       ])
       setJobs(prev => prev.filter(j => j.status === 'pending' || j.status === 'processing'))
     } catch {

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -97,6 +97,7 @@ function runToJob(r: SuggestionRunView): Job {
     r.status === 'running' ? 'processing'
       : r.status === 'completed' ? 'done'
       : r.status === 'failed' ? 'failed'
+      : r.status === 'cancelled' ? 'cancelled'
       : 'pending'
   return {
     id: r.id,

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -510,6 +510,7 @@ export default function JobsPage() {
   const [error, setError] = useState<string | null>(null)
   const [clearingAll, setClearingAll] = useState(false)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const burstTimers = useRef<Array<ReturnType<typeof setTimeout>>>([])
   usePageTitle('Jobs')
 
   const loadJobs = async () => {
@@ -538,8 +539,25 @@ export default function JobsPage() {
 
   useEffect(() => {
     loadJobs()
+    return () => {
+      burstTimers.current.forEach(t => clearTimeout(t))
+      burstTimers.current = []
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // AdminRunSuggestions enqueues River jobs asynchronously — the run rows
+  // don't exist until the worker picks them up. A single reload races the
+  // worker, so fire a short burst instead to catch the run once it lands.
+  const burstReload = () => {
+    burstTimers.current.forEach(t => clearTimeout(t))
+    burstTimers.current = []
+    loadJobs()
+    for (const delay of [600, 1500, 3000, 6000]) {
+      const t = setTimeout(loadJobs, delay)
+      burstTimers.current.push(t)
+    }
+  }
 
   // Auto-poll while any job is active
   useEffect(() => {
@@ -617,7 +635,7 @@ export default function JobsPage() {
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
           Scheduled jobs
         </h2>
-        <AISuggestionsJobCard onRunKicked={loadJobs} />
+        <AISuggestionsJobCard onRunKicked={burstReload} />
       </section>
 
       <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">

--- a/src/types.ts
+++ b/src/types.ts
@@ -509,3 +509,85 @@ export interface LibraryMember {
   invited_by?: string
   tags: Tag[]
 }
+
+// ─── AI ──────────────────────────────────────────────────────────────────────
+
+export interface AIConfigField {
+  key: string
+  label: string
+  type: string // "password" | "text" | "url" | "model"
+  required: boolean
+  placeholder?: string
+  help_text?: string
+  options?: string[]
+}
+
+export interface AIProviderStatus {
+  name: string
+  display_name: string
+  description: string
+  help_text?: string
+  help_url?: string
+  config_fields: AIConfigField[]
+  enabled: boolean
+  active: boolean
+  has_api_key: boolean
+  config?: Record<string, string>
+}
+
+export interface AIPermissions {
+  reading_history: boolean
+  ratings: boolean
+  favourites: boolean
+  full_library: boolean
+  taste_profile: boolean
+}
+
+export interface UserAIPrefs {
+  opt_in: boolean
+}
+
+export interface SuggestionView {
+  id: string
+  type: string // "buy" | "read_next"
+  book_id?: string
+  book_edition_id?: string
+  library_id?: string
+  title: string
+  author?: string
+  isbn?: string
+  cover_url?: string
+  reasoning?: string
+  status: string // "new" | "dismissed" | "interested" | "added_to_library"
+  created_at: string
+}
+
+export interface JobSummary {
+  id: string
+  display_name: string
+  description: string
+  kind: string
+  enabled: boolean
+}
+
+export interface AISuggestionsJobConfig {
+  enabled: boolean
+  interval_minutes: number
+  max_buy_per_user: number
+  max_read_next_per_user: number
+  include_taste_profile: boolean
+  user_run_rate_limit_per_day: number
+}
+
+// TasteProfile is the JSON shape stored per-user. All fields optional —
+// empty categories simply aren't sent to the AI. Chip-style categories
+// (genres, themes, formats) use `love` / `avoid` lists rather than per-item
+// maps so the model prompt is compact and human-readable.
+export interface TasteProfile {
+  genres?: { love?: string[]; avoid?: string[]; favourite?: string[] }
+  themes?: { love?: string[]; avoid?: string[] }
+  formats?: { love?: string[]; avoid?: string[] }
+  era?: string
+  favourite_authors?: string[]
+  hard_nos?: string
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -562,6 +562,35 @@ export interface SuggestionView {
   created_at: string
 }
 
+export interface SuggestionRunView {
+  id: string
+  user_id?: string // only set on admin-scoped responses
+  triggered_by: string // scheduler | admin | user
+  provider_type: string
+  model_id?: string
+  status: string // running | completed | failed
+  error?: string
+  tokens_in: number
+  tokens_out: number
+  estimated_cost_usd: number
+  started_at: string
+  finished_at?: string
+}
+
+// SuggestionRunEvent is one observable step in a pipeline run. `content`
+// shape depends on `type`; the UI renders raw JSON for unknown types.
+export interface SuggestionRunEvent {
+  seq: number
+  type: string
+  content: Record<string, unknown>
+  created_at: string
+}
+
+export interface SuggestionRunDetail {
+  run: SuggestionRunView
+  events: SuggestionRunEvent[]
+}
+
 export interface JobSummary {
   id: string
   display_name: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -606,6 +606,8 @@ export interface AISuggestionsJobConfig {
   max_read_next_per_user: number
   include_taste_profile: boolean
   user_run_rate_limit_per_day: number
+  max_tokens_initial: number
+  max_tokens_backfill: number
 }
 
 // TasteProfile is the JSON shape stored per-user. All fields optional —


### PR DESCRIPTION
## Summary
- Client surfaces for the AI suggestions feature landing in `librarium-api` 26.4.1.
- **Admin → Connections → AI**: provider cards rendered from server-declared `config_fields`, test-connection button, active-provider selector, and two-layer permissions toggles.
- **Profile → AI Privacy**: opt-in toggle + taste profile form (3-way chips for genres/themes/formats, era, favourite authors, hard-nos).
- **Admin → Settings → Jobs**: expandable AI suggestions job config card (cadence, per-user caps, rate limit, "Run now").
- **Dashboard widgets** (Read Next / Buy) hidden when empty. **`/suggestions`** full-list page with filter tabs and user-scoped "Run now".
- `en-CA` and `fr-FR` translations for every new surface.
- Also rolls the previously-merged Helm chart (`deploy/helm/librarium-web`) into the 26.4.1 release notes.

Companion API PR: FireBall1725/librarium-api#6
Plan: `plans/ai-suggestions.md` in the workspace repo.

## Test plan
- [ ] `npm install && npm run build` succeeds; `npx eslint src/` reports 0 new errors.
- [ ] Admin: `/admin/connections/ai` — configure a provider, hit Test, set active, toggle permissions.
- [ ] User: `/profile` — turn on AI opt-in, fill a small taste profile, save.
- [ ] Jobs: `/admin/settings/jobs` — expand AI suggestions card, edit cadence + caps, save, "Run now".
- [ ] Dashboard: widgets render when suggestions exist; hidden when none.
- [ ] `/suggestions`: filter tabs work; "Run now" triggers a run; rate limit surfaces an error toast.
- [ ] `fr-FR`: all new AI surfaces use French strings.