### PR TITLE
Railway deploy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ This project uses **`YY.MM.revision`** (e.g. `26.4.0`, `26.4.1`):
 
 Versions `0.1.0` → `0.13.0` predate this scheme. `26.4.0` is the first release cut under the new format and the first release of `librarium-web` as an independent repository.
 
+## [26.4.2] — Railway deploy support
+
+Deployment-infrastructure release: makes the web image friendly to PaaS platforms that route services via arbitrary internal DNS names instead of the docker-compose service-name convention.
+
+### Changed
+
+- `nginx.conf` is now `nginx.conf.template`, consumed at container start via nginx's built-in envsubst step. The API upstream is controlled by two new env vars — `API_UPSTREAM` (default `librarium-api`) and `API_UPSTREAM_PORT` (default `8080`) — so the existing Docker Compose deployment keeps working unchanged, while PaaS users (Railway, Fly, Render) can point the proxy at their api service's private DNS.
+
+### Added
+
+- `railway.toml` at the repo root so Railway picks up the Dockerfile build and healthcheck without extra config.
+- README section describing the new `API_UPSTREAM` / `API_UPSTREAM_PORT` variables and linking to the Railway walkthrough in the api repo.
+
 ## [26.4.1] — AI-powered book suggestions
 
 Client-side surfaces for the AI suggestions feature landing in `librarium-api` 26.4.1. Also ships the previously-merged Helm chart and associated packaging work.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,12 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# nginx:alpine auto-envsubsts any *.template in /etc/nginx/templates/ on
+# boot. API_UPSTREAM defaults to the docker-compose service name, so the
+# existing full-stack compose deployment works unchanged; PaaS users
+# (Railway, Fly, etc.) override it to point at their api service's
+# internal DNS name.
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+ENV API_UPSTREAM=librarium-api
+ENV API_UPSTREAM_PORT=8080
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 ENV API_UPSTREAM=librarium-api
 ENV API_UPSTREAM_PORT=8080
+ENV PORT=3000
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # (Railway, Fly, etc.) override it to point at their api service's
 # internal DNS name.
 COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY docker-entrypoint-resolvers.sh /usr/local/bin/docker-entrypoint-resolvers.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-resolvers.sh
 ENV API_UPSTREAM=librarium-api
 ENV API_UPSTREAM_PORT=8080
 ENV PORT=3000
 EXPOSE 3000
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint-resolvers.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -42,14 +42,18 @@ See [`deploy/kubernetes/README.md`](./deploy/kubernetes/README.md) for the walkt
 
 ### Docker (web only, advanced)
 
-If you already have the API running elsewhere and just want to build the web image locally:
+If you already have the API running elsewhere and just want to run the web image:
 
 ```bash
 docker build -t librarium-web .
-docker run -p 3000:3000 librarium-web
+docker run -p 3000:3000 -e API_UPSTREAM=my-api.internal -e API_UPSTREAM_PORT=8080 librarium-web
 ```
 
-You'll need to override `nginx.conf` (or rebuild the image with a patched one) so `/api` proxies to your API host instead of the default `http://librarium-api:8080`.
+The container's nginx config is generated from [`nginx.conf.template`](./nginx.conf.template) at boot (via nginx's built-in envsubst). Set `API_UPSTREAM` and `API_UPSTREAM_PORT` to point `/api` at your API host. Defaults are `librarium-api` and `8080`, matching the full-stack Docker Compose deployment.
+
+### Railway (managed PaaS)
+
+The repo ships a `railway.toml` so Railway builds with the right Dockerfile. Deploy it alongside [`librarium-api`](https://github.com/FireBall1725/librarium-api) in the same Railway project and set `API_UPSTREAM=${{api.RAILWAY_PRIVATE_DOMAIN}}` on the web service. Full walkthrough: [`librarium-api/deploy/railway/`](https://github.com/fireball1725/librarium-api/tree/main/deploy/railway).
 
 ## Versioning
 

--- a/docker-entrypoint-resolvers.sh
+++ b/docker-entrypoint-resolvers.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Export RESOLVERS for the nginx envsubst templating. The stock
+# nginx:alpine image ships /docker-entrypoint.d/15-local-resolvers.envsh
+# that does this already, but the entrypoint sources .envsh files inside
+# a pipe-subshell — in practice the export does not always reach the
+# sibling 20-envsubst-on-templates.sh script, which leaves
+# ${NGINX_LOCAL_RESOLVERS} as a literal string in the generated config
+# and nginx fails at boot with "host not found in resolver". Seen on
+# Railway; reproducible elsewhere.
+#
+# Setting RESOLVERS here, before chaining to the stock entrypoint,
+# sidesteps all the subshell timing and is portable across PaaS,
+# docker-compose, and k8s.
+
+set -e
+
+RESOLVERS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
+RESOLVERS=${RESOLVERS% }
+
+if [ -z "$RESOLVERS" ]; then
+    # Shouldn't happen — Docker, Railway, Fly, k8s all populate resolv.conf —
+    # but fall back to public DNS rather than booting a broken nginx.
+    RESOLVERS="8.8.8.8 [2001:4860:4860::8888]"
+fi
+
+export RESOLVERS
+
+exec /docker-entrypoint.sh "$@"

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -13,11 +13,11 @@ server {
     # restart, anything that changes the backend IP) the cached address
     # goes stale and every /api request times out.
     #
-    # NGINX_LOCAL_RESOLVERS is exported by the nginx:alpine entrypoint
-    # (/docker-entrypoint.d/15-local-resolvers.envsh) from the container's
-    # /etc/resolv.conf — Docker's embedded DNS in compose, the platform's
-    # recursor on Railway/Fly/k8s.
-    resolver ${NGINX_LOCAL_RESOLVERS} ipv6=on valid=10s;
+    # RESOLVERS is parsed from /etc/resolv.conf by docker-entrypoint-resolvers.sh
+    # (our wrapper entrypoint) and exported before the stock nginx entrypoint
+    # runs envsubst. Covers Docker's embedded DNS in compose, and whatever
+    # recursor the PaaS gives us on Railway/Fly/k8s.
+    resolver ${RESOLVERS} ipv6=on valid=10s;
 
     # API_UPSTREAM is substituted at container start via nginx's
     # /docker-entrypoint.d/20-envsubst-on-templates.sh. Default value is

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,5 +1,9 @@
 server {
-    listen 3000;
+    # PORT is envsubst'd at container start. Defaults to 3000 (set in the
+    # Dockerfile) so existing Docker Compose deployments keep working; on
+    # Railway / Fly / other PaaS, the platform-injected $PORT wins and
+    # nginx binds to whatever port the platform routes traffic to.
+    listen ${PORT};
     root /usr/share/nginx/html;
     index index.html;
 

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -7,14 +7,30 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Runtime DNS resolution for the api upstream. Without this, nginx
+    # resolves ${API_UPSTREAM} once at config-parse time and caches the
+    # IP forever — when the api instance rotates (Railway redeploy, k8s
+    # restart, anything that changes the backend IP) the cached address
+    # goes stale and every /api request times out.
+    #
+    # NGINX_LOCAL_RESOLVERS is exported by the nginx:alpine entrypoint
+    # (/docker-entrypoint.d/15-local-resolvers.envsh) from the container's
+    # /etc/resolv.conf — Docker's embedded DNS in compose, the platform's
+    # recursor on Railway/Fly/k8s.
+    resolver ${NGINX_LOCAL_RESOLVERS} ipv6=on valid=10s;
+
     # API_UPSTREAM is substituted at container start via nginx's
     # /docker-entrypoint.d/20-envsubst-on-templates.sh. Default value is
     # set in the Dockerfile so existing docker-compose deployments (where
     # the api is reachable as `librarium-api`) keep working unchanged.
     # On Railway / Fly / other PaaS, override it with the internal DNS
     # name of the api service (e.g. ${{api.RAILWAY_PRIVATE_DOMAIN}}).
+    #
+    # The `set` + variable in proxy_pass forces per-request resolution
+    # via the resolver above rather than parse-time caching.
     location /api {
-        proxy_pass http://${API_UPSTREAM}:${API_UPSTREAM_PORT};
+        set $api_upstream ${API_UPSTREAM}:${API_UPSTREAM_PORT};
+        proxy_pass http://$api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -23,7 +39,8 @@ server {
     }
 
     location /health {
-        proxy_pass http://${API_UPSTREAM}:${API_UPSTREAM_PORT};
+        set $health_upstream ${API_UPSTREAM}:${API_UPSTREAM_PORT};
+        proxy_pass http://$health_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -3,9 +3,14 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Proxy API and health requests to the backend service
+    # API_UPSTREAM is substituted at container start via nginx's
+    # /docker-entrypoint.d/20-envsubst-on-templates.sh. Default value is
+    # set in the Dockerfile so existing docker-compose deployments (where
+    # the api is reachable as `librarium-api`) keep working unchanged.
+    # On Railway / Fly / other PaaS, override it with the internal DNS
+    # name of the api service (e.g. ${{api.RAILWAY_PRIVATE_DOMAIN}}).
     location /api {
-        proxy_pass http://librarium-api:8080;
+        proxy_pass http://${API_UPSTREAM}:${API_UPSTREAM_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -14,7 +19,7 @@ server {
     }
 
     location /health {
-        proxy_pass http://librarium-api:8080;
+        proxy_pass http://${API_UPSTREAM}:${API_UPSTREAM_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,24 @@
+# Railway build/deploy config for librarium-web.
+#
+# Build: uses the repo Dockerfile (multi-stage: vite build → nginx:alpine).
+# The container listens on :3000. On boot, nginx envsubsts nginx.conf.template
+# using API_UPSTREAM and API_UPSTREAM_PORT — set those on the Railway service
+# to point at the sibling api service's internal DNS.
+#
+# Required env vars on Railway:
+#   API_UPSTREAM       e.g. ${{api.RAILWAY_PRIVATE_DOMAIN}}
+#   API_UPSTREAM_PORT  e.g. 8080
+#
+# Leave them unset for a fresh one-click deploy and the Dockerfile defaults
+# (librarium-api:8080) kick in — which won't resolve on Railway's network,
+# so the template/README spells out wiring them up.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary
- `nginx.conf` is now `nginx.conf.template`, consumed by nginx's built-in envsubst at boot. `API_UPSTREAM` / `API_UPSTREAM_PORT` control the api proxy target; defaults (`librarium-api:8080`) keep the existing Docker Compose deploy working unchanged
- `railway.toml` at the repo root so Railway picks up the Dockerfile build + healthcheck without extra config
- README section documenting the new env vars and linking to the Railway walkthrough in the api repo

## Test plan
- [ ] Existing Docker Compose stack still works (env var defaults match old service name)
- [ ] Deploy `feat/railway-deploy` (both repos) to Railway end-to-end per `librarium-api/deploy/railway/`
- [ ] Confirm `/api/*` reaches api via private DNS after setting `API_UPSTREAM=${{api.RAILWAY_PRIVATE_DOMAIN}}`
- [ ] Confirm SPA routes fall back to `index.html`