### PR TITLE
ci: move version ownership to release workflow; local builds auto-tag YY.M.DEV

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
-      next_dev: ${{ steps.version.outputs.next_dev }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "npm"
 
       - name: Configure git
         run: |
@@ -66,23 +60,12 @@ jobs:
           fi
 
           VERSION="${PREFIX}.${REV}"
-          NEXT_DEV="${PREFIX}.$((REV + 1))-dev"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "next_dev=$NEXT_DEV" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
 
-      - name: Update package.json (release)
-        run: |
-          npm version --no-git-tag-version --allow-same-version "${{ steps.version.outputs.version }}"
-
-      - name: Commit + tag release
-        if: ${{ inputs.dry-run == false }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          git add package.json package-lock.json
-          git commit -m "release: ${VERSION}"
-          git tag "v${VERSION}"
-
+      # The version lives only in the git tag and in the image the build embeds.
+      # vite.config.ts reads LIBRARIUM_VERSION at build time; Dockerfile forwards it
+      # as a build-arg. Local dev builds auto-compute "{YY}.{M}.DEV".
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -101,22 +84,18 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            LIBRARIUM_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ghcr.io/fireball1725/librarium-web:${{ steps.version.outputs.version }}
             ghcr.io/fireball1725/librarium-web:latest
 
-      - name: Bump to next -dev
+      - name: Tag release
         if: ${{ inputs.dry-run == false }}
         run: |
-          npm version --no-git-tag-version --allow-same-version "${{ steps.version.outputs.next_dev }}"
-          git add package.json package-lock.json
-          git commit -m "chore: bump to ${{ steps.version.outputs.next_dev }}"
-
-      - name: Push commits and tag
-        if: ${{ inputs.dry-run == false }}
-        run: |
-          git push origin HEAD:main
-          git push origin "v${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Create GitHub Release
         if: ${{ inputs.dry-run == false }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
+ARG LIBRARIUM_VERSION=""
+ENV LIBRARIUM_VERSION=$LIBRARIUM_VERSION
 RUN npm run build
 
 FROM nginx:alpine

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "26.4.1-dev",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "26.4.1-dev",
+      "version": "0.0.0",
       "dependencies": {
         "emoji-picker-react": "^4.18.0",
         "i18next": "^26.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "26.4.1",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,25 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import pkg from './package.json' with { type: 'json' }
 
 const apiTarget = process.env.VITE_API_PROXY_TARGET || 'http://localhost:8080'
+
+// Display version: release builds get LIBRARIUM_VERSION injected by CI (e.g. "26.4.1").
+// Local/dev builds auto-compute "{YY}.{M}.DEV" from today's date so an uninjected build
+// is visibly distinguishable from a release. Matches the api repo's version.go logic.
+function computeVersion(): string {
+  const injected = process.env.LIBRARIUM_VERSION?.trim()
+  if (injected) return injected
+  const now = new Date()
+  const yy = now.getUTCFullYear() % 100
+  const m = now.getUTCMonth() + 1
+  return `${yy}.${m}.DEV`
+}
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
+    __APP_VERSION__: JSON.stringify(computeVersion()),
   },
   server: {
     host: '0.0.0.0',


### PR DESCRIPTION
- Display version is now injected at build time via `LIBRARIUM_VERSION` (set by `release.yml` for tagged builds). `vite.config.ts` falls back to auto-computed `YY.M.DEV` from today's date when the env var is unset, so local `npm run dev` and uninjected Docker builds are visibly marked as dev.
- `release.yml` no longer hand-mutates `package.json` or commits `release:`/`-dev` churn — it just tags and builds the image with the computed version. Matches `librarium-api`'s pattern; satisfies the CLAUDE.md rule that version bumps are owned by CI.