### PR TITLE
feat(suggestions): steered suggestions UI

### DIFF
--- a/src/components/CustomRequestModal.tsx
+++ b/src/components/CustomRequestModal.tsx
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useAuth } from '../auth/AuthContext'
+import type {
+  ContributorResult,
+  Genre,
+  MeSeriesResult,
+  MeTagResult,
+  SuggestionSteeringInput,
+  SuggestionSteeringView,
+} from '../types'
+
+interface CustomRequestModalProps {
+  open: boolean
+  onClose: () => void
+  onSubmit: (steering: SuggestionSteeringInput) => Promise<void> | void
+  submitting: boolean
+  // Pre-fills the modal when re-running or editing a steered ask.
+  initial?: SuggestionSteeringView | null
+}
+
+// Palette per field type — mirrors mockup sections 2/3/4 so the banner and
+// Recent Runs entries can visually echo what's in the modal.
+type Palette = 'indigo' | 'purple' | 'emerald' | 'amber'
+
+type Chip = { id: string; label: string }
+
+const paletteClasses: Record<
+  Palette,
+  { chip: string; chipButton: string }
+> = {
+  indigo: {
+    chip: 'bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300',
+    chipButton: 'text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-200',
+  },
+  purple: {
+    chip: 'bg-purple-100 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300',
+    chipButton: 'text-purple-500 hover:text-purple-700 dark:hover:text-purple-200',
+  },
+  emerald: {
+    chip: 'bg-emerald-100 dark:bg-emerald-900/50 text-emerald-700 dark:text-emerald-300',
+    chipButton: 'text-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-200',
+  },
+  amber: {
+    chip: 'bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300',
+    chipButton: 'text-amber-500 hover:text-amber-700 dark:hover:text-amber-200',
+  },
+}
+
+interface ChipComboProps {
+  label: string
+  palette: Palette
+  placeholder: string
+  chips: Chip[]
+  query: string
+  onQueryChange: (v: string) => void
+  onRemove: (id: string) => void
+  results: Chip[]
+  onPick: (c: Chip) => void
+  searching: boolean
+  disabled: boolean
+  footnote?: string
+}
+
+// ChipCombo is the shared "chips in a bordered box + inline search input"
+// widget used for Authors / Series / Genres / Tags. The mockup puts the
+// search input inline with the chips; results surface in a floating panel
+// beneath the box.
+function ChipCombo({
+  label,
+  palette,
+  placeholder,
+  chips,
+  query,
+  onQueryChange,
+  onRemove,
+  results,
+  onPick,
+  searching,
+  disabled,
+  footnote,
+}: ChipComboProps) {
+  const pal = paletteClasses[palette]
+  const showResults = results.length > 0
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+        {label}
+      </label>
+      <div className="relative">
+        <div className="min-h-[38px] rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 px-2 py-1.5 flex flex-wrap gap-1.5 items-center">
+          {chips.map(c => (
+            <span
+              key={c.id}
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs ${pal.chip}`}
+            >
+              {c.label}
+              <button
+                type="button"
+                onClick={() => onRemove(c.id)}
+                disabled={disabled}
+                className={`${pal.chipButton} disabled:opacity-50`}
+                aria-label={`Remove ${c.label}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          <input
+            type="text"
+            value={query}
+            onChange={e => onQueryChange(e.target.value)}
+            placeholder={placeholder}
+            disabled={disabled}
+            className="flex-1 min-w-[8rem] bg-transparent outline-none text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400"
+          />
+        </div>
+        {showResults && (
+          <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg max-h-60 overflow-y-auto">
+            {results.map(r => (
+              <button
+                type="button"
+                key={r.id}
+                onClick={() => onPick(r)}
+                className="block w-full text-left px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-blue-50 dark:hover:bg-blue-900/30"
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+        )}
+        {searching && !showResults && query.trim().length >= 2 && (
+          <p className="absolute right-2 top-2 text-xs text-gray-400">Searching…</p>
+        )}
+      </div>
+      {footnote && (
+        <p className="mt-1 text-[11px] text-gray-500 dark:text-gray-400">{footnote}</p>
+      )}
+    </div>
+  )
+}
+
+export default function CustomRequestModal({
+  open,
+  onClose,
+  onSubmit,
+  submitting,
+  initial,
+}: CustomRequestModalProps) {
+  const { callApi } = useAuth()
+
+  // Selected chips for each field.
+  const [authors, setAuthors] = useState<Chip[]>([])
+  const [series, setSeries] = useState<Chip[]>([])
+  const [genresSel, setGenresSel] = useState<Chip[]>([])
+  const [tags, setTags] = useState<Chip[]>([])
+  const [notes, setNotes] = useState('')
+
+  // Per-field search query + results.
+  const [authorQuery, setAuthorQuery] = useState('')
+  const [authorResults, setAuthorResults] = useState<Chip[]>([])
+  const [authorSearching, setAuthorSearching] = useState(false)
+
+  const [seriesQuery, setSeriesQuery] = useState('')
+  const [seriesResults, setSeriesResults] = useState<Chip[]>([])
+  const [seriesSearching, setSeriesSearching] = useState(false)
+
+  const [genreQuery, setGenreQuery] = useState('')
+  const [allGenres, setAllGenres] = useState<Genre[]>([])
+  const [genresLoading, setGenresLoading] = useState(false)
+
+  const [tagQuery, setTagQuery] = useState('')
+  const [tagResults, setTagResults] = useState<Chip[]>([])
+  const [tagSearching, setTagSearching] = useState(false)
+
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+
+  // Pre-fill on open from `initial`.
+  useEffect(() => {
+    if (!open) return
+    setAuthors((initial?.authors ?? []).map(a => ({ id: a.id, label: a.name })))
+    setSeries((initial?.series ?? []).map(s => ({ id: s.id, label: s.name })))
+    setGenresSel((initial?.genres ?? []).map(g => ({ id: g.id, label: g.name })))
+    setTags((initial?.tags ?? []).map(t => ({ id: t.id, label: t.name })))
+    setNotes(initial?.notes ?? '')
+    setAuthorQuery('')
+    setAuthorResults([])
+    setSeriesQuery('')
+    setSeriesResults([])
+    setGenreQuery('')
+    setTagQuery('')
+    setTagResults([])
+  }, [open, initial])
+
+  // Genres are global and small — load once, filter locally.
+  useEffect(() => {
+    if (!open || allGenres.length > 0 || genresLoading) return
+    setGenresLoading(true)
+    callApi<Genre[]>('/api/v1/genres')
+      .then(gs => setAllGenres(gs ?? []))
+      .catch(() => setAllGenres([]))
+      .finally(() => setGenresLoading(false))
+  }, [open, allGenres.length, genresLoading, callApi])
+
+  // Authors search — debounced, min 2 chars.
+  useEffect(() => {
+    if (!open) return
+    const q = authorQuery.trim()
+    if (q.length < 2) {
+      setAuthorResults([])
+      return
+    }
+    let cancelled = false
+    const id = setTimeout(() => {
+      setAuthorSearching(true)
+      callApi<ContributorResult[]>(`/api/v1/contributors?q=${encodeURIComponent(q)}`)
+        .then(rs => {
+          if (cancelled) return
+          const selectedIds = new Set(authors.map(a => a.id))
+          setAuthorResults(
+            (rs ?? [])
+              .filter(r => !selectedIds.has(r.id))
+              .slice(0, 8)
+              .map(r => ({ id: r.id, label: r.name })),
+          )
+        })
+        .catch(() => !cancelled && setAuthorResults([]))
+        .finally(() => !cancelled && setAuthorSearching(false))
+    }, 200)
+    return () => {
+      cancelled = true
+      clearTimeout(id)
+    }
+  }, [authorQuery, open, callApi, authors])
+
+  // Series search — debounced, min 2 chars.
+  useEffect(() => {
+    if (!open) return
+    const q = seriesQuery.trim()
+    if (q.length < 2) {
+      setSeriesResults([])
+      return
+    }
+    let cancelled = false
+    const id = setTimeout(() => {
+      setSeriesSearching(true)
+      callApi<MeSeriesResult[]>(`/api/v1/me/series?q=${encodeURIComponent(q)}`)
+        .then(rs => {
+          if (cancelled) return
+          const selectedIds = new Set(series.map(s => s.id))
+          setSeriesResults(
+            (rs ?? [])
+              .filter(r => !selectedIds.has(r.id))
+              .slice(0, 8)
+              .map(r => ({ id: r.id, label: r.name })),
+          )
+        })
+        .catch(() => !cancelled && setSeriesResults([]))
+        .finally(() => !cancelled && setSeriesSearching(false))
+    }, 200)
+    return () => {
+      cancelled = true
+      clearTimeout(id)
+    }
+  }, [seriesQuery, open, callApi, series])
+
+  // Tags search — debounced, min 2 chars. Results append " · <library>"
+  // when the same tag name exists in multiple libraries.
+  useEffect(() => {
+    if (!open) return
+    const q = tagQuery.trim()
+    if (q.length < 2) {
+      setTagResults([])
+      return
+    }
+    let cancelled = false
+    const id = setTimeout(() => {
+      setTagSearching(true)
+      callApi<MeTagResult[]>(`/api/v1/me/tags?q=${encodeURIComponent(q)}`)
+        .then(rs => {
+          if (cancelled) return
+          const selectedIds = new Set(tags.map(t => t.id))
+          setTagResults(
+            (rs ?? [])
+              .filter(r => !selectedIds.has(r.id))
+              .slice(0, 8)
+              .map(r => ({
+                id: r.id,
+                label: r.ambiguous ? `${r.name} · ${r.library_name}` : r.name,
+              })),
+          )
+        })
+        .catch(() => !cancelled && setTagResults([]))
+        .finally(() => !cancelled && setTagSearching(false))
+    }, 200)
+    return () => {
+      cancelled = true
+      clearTimeout(id)
+    }
+  }, [tagQuery, open, callApi, tags])
+
+  // Close on Escape so the modal obeys platform conventions.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose, submitting])
+
+  // Genre search is client-side over the globally-loaded list. The results
+  // pane only opens once the user starts typing — mirrors the other fields
+  // so Genres doesn't auto-balloon open on mount and push everything below
+  // off-screen.
+  const genreResults = useMemo<Chip[]>(() => {
+    const q = genreQuery.trim().toLowerCase()
+    if (q.length === 0) return []
+    const selectedIds = new Set(genresSel.map(g => g.id))
+    return allGenres
+      .filter(g => !selectedIds.has(g.id) && g.name.toLowerCase().includes(q))
+      .slice(0, 8)
+      .map(g => ({ id: g.id, label: g.name }))
+  }, [allGenres, genreQuery, genresSel])
+
+  const canSubmit =
+    authors.length > 0 ||
+    series.length > 0 ||
+    genresSel.length > 0 ||
+    tags.length > 0 ||
+    notes.trim().length > 0
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit || submitting) return
+    const payload: SuggestionSteeringInput = {}
+    if (authors.length > 0) payload.author_ids = authors.map(a => a.id)
+    if (series.length > 0) payload.series_ids = series.map(s => s.id)
+    if (genresSel.length > 0) payload.genre_ids = genresSel.map(g => g.id)
+    if (tags.length > 0) payload.tag_ids = tags.map(t => t.id)
+    const trimmed = notes.trim()
+    if (trimmed.length > 0) payload.notes = trimmed
+    await onSubmit(payload)
+  }, [canSubmit, submitting, authors, series, genresSel, tags, notes, onSubmit])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 overflow-y-auto py-8 px-4"
+      onClick={() => {
+        if (!submitting) onClose()
+      }}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        ref={dialogRef}
+        onClick={e => e.stopPropagation()}
+        className="w-full max-w-xl rounded-xl border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg"
+      >
+        <div className="p-5 border-b border-gray-200 dark:border-gray-800 flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+              Custom suggestion request
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Pick any combination. Leave fields blank if they don't apply.
+              This uses one of your daily runs.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="p-1 -m-1 rounded text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-50"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-5 space-y-5">
+          <ChipCombo
+            label="Authors"
+            palette="indigo"
+            placeholder="Type to search authors…"
+            chips={authors}
+            query={authorQuery}
+            onQueryChange={setAuthorQuery}
+            onRemove={id => setAuthors(prev => prev.filter(a => a.id !== id))}
+            results={authorResults}
+            onPick={c => {
+              setAuthors(prev => [...prev, c])
+              setAuthorQuery('')
+              setAuthorResults([])
+            }}
+            searching={authorSearching}
+            disabled={submitting}
+          />
+
+          <ChipCombo
+            label="Series"
+            palette="purple"
+            placeholder="Type to search series…"
+            chips={series}
+            query={seriesQuery}
+            onQueryChange={setSeriesQuery}
+            onRemove={id => setSeries(prev => prev.filter(s => s.id !== id))}
+            results={seriesResults}
+            onPick={c => {
+              setSeries(prev => [...prev, c])
+              setSeriesQuery('')
+              setSeriesResults([])
+            }}
+            searching={seriesSearching}
+            disabled={submitting}
+          />
+
+          <ChipCombo
+            label="Genres"
+            palette="emerald"
+            placeholder={
+              genresLoading ? 'Loading genres…' : 'Type to search genres…'
+            }
+            chips={genresSel}
+            query={genreQuery}
+            onQueryChange={setGenreQuery}
+            onRemove={id => setGenresSel(prev => prev.filter(g => g.id !== id))}
+            results={genreResults}
+            onPick={c => {
+              setGenresSel(prev => [...prev, c])
+              setGenreQuery('')
+            }}
+            searching={false}
+            disabled={submitting || genresLoading}
+          />
+
+          <ChipCombo
+            label="Tags"
+            palette="amber"
+            placeholder="Type to search tags…"
+            chips={tags}
+            query={tagQuery}
+            onQueryChange={setTagQuery}
+            onRemove={id => setTags(prev => prev.filter(t => t.id !== id))}
+            results={tagResults}
+            onPick={c => {
+              setTags(prev => [...prev, c])
+              setTagQuery('')
+              setTagResults([])
+            }}
+            searching={tagSearching}
+            disabled={submitting}
+            footnote="Tags are per-library; names suffixed with library when ambiguous."
+          />
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+              Notes (optional)
+            </label>
+            <textarea
+              value={notes}
+              onChange={e => setNotes(e.target.value)}
+              placeholder='e.g. "long series I can binge" or "similar tone to Piranesi"'
+              disabled={submitting}
+              rows={3}
+              className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-950 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 resize-y"
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 p-4 border-t border-gray-200 dark:border-gray-800">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit || submitting}
+            className="rounded-md bg-blue-600 text-white px-3 py-1.5 text-sm font-medium hover:bg-blue-700 disabled:opacity-50"
+          >
+            {submitting ? 'Generating…' : 'Generate suggestions'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
+import type { SuggestionQuotaView } from '../types'
 
 type Theme = 'light' | 'dark' | 'system'
 
@@ -41,7 +42,7 @@ const LIBRARY_SECTIONS: Array<{ section: string; labelKey: string }> = [
 ]
 
 export default function Layout() {
-  const { user, logout } = useAuth()
+  const { user, logout, callApi } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
   const { t } = useTranslation()
@@ -59,6 +60,32 @@ export default function Layout() {
     () => (localStorage.getItem('theme') as Theme) ?? 'system'
   )
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  // Hide the Suggestions nav entry when AI is unavailable for this user
+  // (job disabled, no active provider, or not opted in). Start undefined so
+  // we don't flash the link before we know — the nav just omits it for the
+  // first render tick either way. Re-fetch when the user flips opt-in on
+  // the profile page by listening to a custom event.
+  const [suggestionsAvailable, setSuggestionsAvailable] = useState<boolean | undefined>(undefined)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = () => {
+      callApi<SuggestionQuotaView>('/api/v1/me/suggestions/quota')
+        .then(q => {
+          if (!cancelled) setSuggestionsAvailable(q?.available ?? false)
+        })
+        .catch(() => {
+          if (!cancelled) setSuggestionsAvailable(false)
+        })
+    }
+    load()
+    const onRefresh = () => load()
+    window.addEventListener('librarium:ai-prefs-changed', onRefresh)
+    return () => {
+      cancelled = true
+      window.removeEventListener('librarium:ai-prefs-changed', onRefresh)
+    }
+  }, [callApi])
 
   useEffect(() => {
     applyTheme(theme)
@@ -179,7 +206,9 @@ export default function Layout() {
             </div>
           )}
 
-          <NavLink to="/suggestions" className={navClass}>{t('nav.suggestions')}</NavLink>
+          {suggestionsAvailable && (
+            <NavLink to="/suggestions" className={navClass}>{t('nav.suggestions')}</NavLink>
+          )}
 
           <div className="pt-4">
             <p className="px-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -163,6 +163,8 @@ export default function ProfilePage() {
         body: JSON.stringify({ opt_in: next }),
       })
       setAiOptIn(next)
+      // Notify the sidebar so the Suggestions link shows/hides without reload.
+      window.dispatchEvent(new Event('librarium:ai-prefs-changed'))
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Failed to update AI preferences', { variant: 'error' })
     } finally {

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -2,34 +2,27 @@
 // Copyright (C) 2026 fireball1725
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth, ApiError } from '../auth/AuthContext'
 import { useToast } from '../components/Toast'
 import PageHeader from '../components/PageHeader'
 import SuggestionCard from '../components/SuggestionCard'
+import CustomRequestModal from '../components/CustomRequestModal'
 import { usePageTitle } from '../hooks/usePageTitle'
-import type { SuggestionView } from '../types'
+import type {
+  SuggestionQuotaView,
+  SuggestionRunView,
+  SuggestionSteeringInput,
+  SuggestionSteeringView,
+  SuggestionView,
+} from '../types'
 
 type TypeFilter = 'all' | 'buy' | 'read_next' | 'saved'
 
-type RunView = {
-  id: string
-  status: 'running' | 'completed' | 'failed' | 'cancelled'
-  started_at: string
-  finished_at?: string
-}
-
-type QuotaView = {
-  used: number
-  limit: number
-  resets_at?: string
-  unlimited: boolean
-}
-
-// SuggestionsPage is the /suggestions overflow surface: users land here from
-// the dashboard widget's "See all" link and can also trigger a user-scoped
-// regen. The dashboard remains the primary surface.
+// SuggestionsPage is the /suggestions overflow surface. Scope model:
+//   - default:    ?run_id absent → mixed pool (status=new + status=interested)
+//   - scoped:     ?run_id=<uuid> → that run's suggestions, banner, pill recount
 export default function SuggestionsPage() {
   const { callApi } = useAuth()
   const { show: showToast } = useToast()
@@ -38,23 +31,33 @@ export default function SuggestionsPage() {
 
   const [searchParams, setSearchParams] = useSearchParams()
   const filter = (searchParams.get('type') as TypeFilter | null) ?? 'all'
-  const isSaved = filter === 'saved'
+  const scopedRunId = searchParams.get('run_id')
+  const isSaved = filter === 'saved' && !scopedRunId
 
   // Keep the two status buckets in separate state so tab counts stay accurate
   // regardless of which tab is active — the All/Read next/Buy counts are all
-  // drawn from newItems, Saved is drawn from savedItems.
+  // drawn from newItems, Saved is drawn from savedItems. In scoped mode, both
+  // come from the same scoped list (we don't render the Saved tab there).
   const [newItems, setNewItems] = useState<SuggestionView[] | null>(null)
   const [savedItems, setSavedItems] = useState<SuggestionView[] | null>(null)
+  const [scopedItems, setScopedItems] = useState<SuggestionView[] | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [running, setRunning] = useState(false)
-  const [quota, setQuota] = useState<QuotaView | null>(null)
-  const [activeRun, setActiveRun] = useState<RunView | null>(null)
+  const [quota, setQuota] = useState<SuggestionQuotaView | null>(null)
+  const [activeRun, setActiveRun] = useState<SuggestionRunView | null>(null)
   const [activeEventCount, setActiveEventCount] = useState<number>(0)
+  const [recentRuns, setRecentRuns] = useState<SuggestionRunView[] | null>(null)
+  const [scopedRun, setScopedRun] = useState<SuggestionRunView | null>(null)
+  const [recentExpanded, setRecentExpanded] = useState(true)
+  const [modalOpen, setModalOpen] = useState(false)
+  // Pre-fill source for the modal — used when user clicks ✎ on the banner or
+  // "Re-run" in the history panel. Null means open blank.
+  const [modalInitial, setModalInitial] = useState<SuggestionSteeringView | null>(null)
   // Track the last-seen running run so we can detect the running→completed
-  // transition and refresh items/quota when it finishes.
+  // transition, refresh items, and auto-scope to it.
   const lastRunningIdRef = useRef<string | null>(null)
 
-  const reload = useCallback(() => {
+  const loadMixed = useCallback(() => {
     setError(null)
     Promise.all([
       callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new'),
@@ -67,12 +70,48 @@ export default function SuggestionsPage() {
       .catch(err => setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' })))
   }, [callApi, t])
 
+  const loadScoped = useCallback((runId: string) => {
+    setError(null)
+    callApi<SuggestionView[]>(`/api/v1/me/suggestions?run_id=${encodeURIComponent(runId)}`)
+      .then(items => setScopedItems(items ?? []))
+      .catch(err => setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' })))
+  }, [callApi, t])
+
+  // Fetch mixed or scoped list depending on URL.
   useEffect(() => {
-    reload()
-  }, [reload])
+    if (scopedRunId) {
+      loadScoped(scopedRunId)
+      // Mixed lists can be cleared — pill counts in scoped mode use scopedItems.
+      setNewItems(null)
+      setSavedItems(null)
+    } else {
+      loadMixed()
+      setScopedItems(null)
+      setScopedRun(null)
+    }
+  }, [scopedRunId, loadScoped, loadMixed])
+
+  // Fetch the scoped run metadata (for the banner) whenever scope changes.
+  useEffect(() => {
+    if (!scopedRunId) {
+      setScopedRun(null)
+      return
+    }
+    let cancelled = false
+    callApi<{ run: SuggestionRunView }>(`/api/v1/me/suggestions/runs/${scopedRunId}`)
+      .then(d => {
+        if (!cancelled) setScopedRun(d?.run ?? null)
+      })
+      .catch(() => {
+        if (!cancelled) setScopedRun(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [scopedRunId, callApi])
 
   const refreshQuota = useCallback(() => {
-    callApi<QuotaView>('/api/v1/me/suggestions/quota')
+    callApi<SuggestionQuotaView>('/api/v1/me/suggestions/quota')
       .then(data => setQuota(data ?? null))
       .catch(() => {})
   }, [callApi])
@@ -81,34 +120,43 @@ export default function SuggestionsPage() {
     refreshQuota()
   }, [refreshQuota])
 
-  // Poll for in-flight runs so we can show progress and auto-refresh items
-  // when a run finishes (covers /run-now kicked from here as well as runs
-  // started by the scheduler or another device).
+  // Poll runs every 4s for (a) in-flight status + event count, (b) the
+  // auto-scope transition when a manual run completes, and (c) powering the
+  // Recent runs panel without a second endpoint.
   useEffect(() => {
     let cancelled = false
     const tick = async () => {
-      let runs: RunView[] | undefined
+      let runs: SuggestionRunView[] | undefined
       try {
-        runs = await callApi<RunView[]>('/api/v1/me/suggestions/runs')
+        runs = await callApi<SuggestionRunView[]>('/api/v1/me/suggestions/runs')
       } catch {
         return
       }
       if (cancelled) return
+      setRecentRuns(runs ?? [])
       const inflight = runs?.find(r => r.status === 'running') ?? null
       setActiveRun(inflight)
       if (inflight) {
         lastRunningIdRef.current = inflight.id
         try {
-          const detail = await callApi<{ run: RunView; events: unknown[] }>(`/api/v1/me/suggestions/runs/${inflight.id}`)
+          const detail = await callApi<{ run: SuggestionRunView; events: unknown[] }>(
+            `/api/v1/me/suggestions/runs/${inflight.id}`,
+          )
           if (!cancelled) setActiveEventCount(detail?.events?.length ?? 0)
         } catch {
           // Leave the previous count if the detail fetch transiently fails.
         }
       } else if (lastRunningIdRef.current !== null) {
-        // Just transitioned running → done; refresh everything.
+        // Just transitioned running → done. Auto-scope to the run we were
+        // watching (user-triggered or otherwise — if it finished while they
+        // were looking, they want to see it).
+        const finishedId = lastRunningIdRef.current
         lastRunningIdRef.current = null
         setActiveEventCount(0)
-        reload()
+        const params = new URLSearchParams(searchParams)
+        params.set('run_id', finishedId)
+        params.delete('type')
+        setSearchParams(params, { replace: true })
         refreshQuota()
       }
     }
@@ -118,53 +166,95 @@ export default function SuggestionsPage() {
       cancelled = true
       clearInterval(id)
     }
-  }, [callApi, reload, refreshQuota])
+  }, [callApi, refreshQuota, searchParams, setSearchParams])
 
   const handleChanged = useCallback(() => {
-    // Status changes (interested / dismissed / added / block) shuffle a row
-    // between the two status buckets — simplest to just refetch both. The
-    // endpoint is cheap and avoids bespoke reconciliation logic.
-    reload()
-  }, [reload])
+    // Status changes shuffle a row between buckets — simplest to just refetch.
+    if (scopedRunId) loadScoped(scopedRunId)
+    else loadMixed()
+  }, [scopedRunId, loadScoped, loadMixed])
 
   const setFilter = (next: TypeFilter) => {
-    if (next === 'all') {
-      searchParams.delete('type')
-    } else {
-      searchParams.set('type', next)
-    }
-    setSearchParams(searchParams, { replace: true })
+    const params = new URLSearchParams(searchParams)
+    if (next === 'all') params.delete('type')
+    else params.set('type', next)
+    setSearchParams(params, { replace: true })
   }
 
-  const runNow = async () => {
-    setRunning(true)
-    try {
-      await callApi('/api/v1/me/suggestions/run', { method: 'POST' })
-      showToast(t('suggestions_page.run_queued'), { variant: 'success' })
-      // Refresh quota immediately so the counter moves without waiting for the
-      // next poll tick. The runs-poll effect handles completion.
-      refreshQuota()
-    } catch (err) {
-      const msg = err instanceof ApiError ? err.message : t('suggestions_page.run_failed')
-      showToast(msg, { variant: 'error' })
-    } finally {
-      setRunning(false)
-    }
+  const setScope = (runId: string | null) => {
+    const params = new URLSearchParams(searchParams)
+    if (runId) params.set('run_id', runId)
+    else params.delete('run_id')
+    // Always drop the type filter when scope changes — we want "All" in the
+    // scoped run by default so the user sees everything that came out of it.
+    params.delete('type')
+    setSearchParams(params, { replace: false })
   }
 
+  const openModal = (initial: SuggestionSteeringView | null) => {
+    setModalInitial(initial)
+    setModalOpen(true)
+  }
+
+  const submitRun = useCallback(
+    async (steering: SuggestionSteeringInput | null) => {
+      setRunning(true)
+      try {
+        const body = steering ? JSON.stringify({ steering }) : undefined
+        await callApi('/api/v1/me/suggestions/run', {
+          method: 'POST',
+          body,
+        })
+        showToast(t('suggestions_page.run_queued'), { variant: 'success' })
+        setModalOpen(false)
+        refreshQuota()
+      } catch (err) {
+        const msg = err instanceof ApiError ? err.message : t('suggestions_page.run_failed')
+        showToast(msg, { variant: 'error' })
+      } finally {
+        setRunning(false)
+      }
+    },
+    [callApi, showToast, t, refreshQuota],
+  )
+
+  const runNow = async () => submitRun(null)
+
+  // Active list + counts: in scoped mode, everything comes from scopedItems
+  // (filtered by type tab). In default mode, today's behaviour.
   const filtered = useMemo(() => {
+    if (scopedRunId) {
+      if (scopedItems === null) return null
+      if (filter === 'all' || filter === 'saved') return scopedItems
+      return scopedItems.filter(s => s.type === filter)
+    }
     if (isSaved) return savedItems
     if (newItems === null) return null
     if (filter === 'all') return newItems
     return newItems.filter(s => s.type === filter)
-  }, [newItems, savedItems, isSaved, filter])
+  }, [scopedRunId, scopedItems, isSaved, filter, newItems, savedItems])
 
-  const buyCount = useMemo(() => newItems?.filter(s => s.type === 'buy').length ?? 0, [newItems])
-  const readNextCount = useMemo(() => newItems?.filter(s => s.type === 'read_next').length ?? 0, [newItems])
-  const savedCount = savedItems?.length ?? 0
+  const pillCounts = useMemo(() => {
+    if (scopedRunId) {
+      const items = scopedItems ?? []
+      return {
+        all: items.length,
+        buy: items.filter(s => s.type === 'buy').length,
+        readNext: items.filter(s => s.type === 'read_next').length,
+        saved: 0,
+      }
+    }
+    return {
+      all: newItems?.length ?? 0,
+      buy: newItems?.filter(s => s.type === 'buy').length ?? 0,
+      readNext: newItems?.filter(s => s.type === 'read_next').length ?? 0,
+      saved: savedItems?.length ?? 0,
+    }
+  }, [scopedRunId, scopedItems, newItems, savedItems])
 
+  const available = quota?.available ?? true
   const quotaExhausted = quota !== null && !quota.unlimited && quota.used >= quota.limit
-  const runDisabled = running || activeRun !== null || quotaExhausted
+  const runDisabled = running || activeRun !== null || quotaExhausted || !available
 
   return (
     <>
@@ -172,91 +262,138 @@ export default function SuggestionsPage() {
         title={t('suggestions_page.title')}
         description={t('suggestions_page.description')}
         actions={
-          <div className="flex items-center gap-3">
-            {quota !== null && (
-              <span className="text-xs text-gray-500 dark:text-gray-400" title={quota.resets_at ? t('suggestions_page.quota.resets_at', { at: new Date(quota.resets_at).toLocaleString() }) : undefined}>
-                {quota.unlimited
-                  ? t('suggestions_page.quota.unlimited', { used: quota.used })
-                  : t('suggestions_page.quota.label', { remaining: Math.max(0, quota.limit - quota.used), limit: quota.limit })}
-              </span>
-            )}
-            <button
-              type="button"
-              onClick={runNow}
-              disabled={runDisabled}
-              className="rounded-md border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
-            >
-              {running || activeRun !== null ? t('suggestions_page.running') : t('suggestions_page.run_now')}
-            </button>
-          </div>
+          available ? (
+            <div className="flex items-center gap-3">
+              {quota !== null && (
+                <span
+                  className="text-xs text-gray-500 dark:text-gray-400"
+                  title={quota.resets_at ? t('suggestions_page.quota.resets_at', { at: new Date(quota.resets_at).toLocaleString() }) : undefined}
+                >
+                  {quota.unlimited
+                    ? t('suggestions_page.quota.unlimited', { used: quota.used })
+                    : t('suggestions_page.quota.label', { remaining: Math.max(0, quota.limit - quota.used), limit: quota.limit })}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => openModal(null)}
+                disabled={runDisabled}
+                className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+              >
+                Custom request…
+              </button>
+              <button
+                type="button"
+                onClick={runNow}
+                disabled={runDisabled}
+                className="rounded-md border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+              >
+                {running || activeRun !== null ? t('suggestions_page.running') : t('suggestions_page.run_now')}
+              </button>
+            </div>
+          ) : null
         }
       />
       <div className="p-4 sm:p-6 space-y-4 max-w-screen-2xl mx-auto">
-        <div className="flex items-center gap-2">
-          <FilterTab active={filter === 'all'} onClick={() => setFilter('all')}>
-            {t('suggestions_page.filters.all', { count: newItems?.length ?? 0 })}
-          </FilterTab>
-          <FilterTab active={filter === 'read_next'} onClick={() => setFilter('read_next')}>
-            {t('suggestions_page.filters.read_next', { count: readNextCount })}
-          </FilterTab>
-          <FilterTab active={filter === 'buy'} onClick={() => setFilter('buy')}>
-            {t('suggestions_page.filters.buy', { count: buyCount })}
-          </FilterTab>
-          <FilterTab active={filter === 'saved'} onClick={() => setFilter('saved')}>
-            {t('suggestions_page.filters.saved', { count: savedCount })}
-          </FilterTab>
-        </div>
-
-        {activeRun && (
-          <div className="flex items-center gap-3 rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-950/40 px-4 py-3">
-            <svg className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400 flex-shrink-0" viewBox="0 0 24 24" fill="none">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
-              <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
-            </svg>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                {t('suggestions_page.progress.title')}
-              </p>
-              <p className="text-xs text-blue-700 dark:text-blue-300">
-                {activeEventCount > 0
-                  ? t('suggestions_page.progress.steps', { count: activeEventCount })
-                  : t('suggestions_page.progress.starting')}
-              </p>
-            </div>
-          </div>
-        )}
-
-        {error ? (
-          <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-4 text-sm text-red-700 dark:text-red-300">
-            {error}
-          </div>
-        ) : filtered === null ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-            {[...Array(6)].map((_, i) => (
-              <div key={i} className="space-y-2">
-                <div className="aspect-[2/3] rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
-                <div className="h-3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
-                <div className="h-2 w-2/3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
-              </div>
-            ))}
-          </div>
-        ) : filtered.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 p-8 text-center">
-            <p className="text-sm font-medium text-gray-900 dark:text-white">
-              {t(isSaved ? 'suggestions_page.saved_empty.title' : 'suggestions_page.empty.title')}
-            </p>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              {t(isSaved ? 'suggestions_page.saved_empty.hint' : 'suggestions_page.empty.hint')}
-            </p>
-          </div>
+        {!available ? (
+          <UnavailableCard reason={quota?.unavailable_reason ?? null} />
         ) : (
-          <div className="flex flex-wrap gap-4">
-            {filtered.map(s => (
-              <SuggestionCard key={s.id} suggestion={s} onChanged={handleChanged} />
-            ))}
-          </div>
+          <>
+            {scopedRunId && (
+              <SteeringBanner
+                run={scopedRun}
+                onEdit={() => openModal(scopedRun?.steering ?? null)}
+                onClear={() => setScope(null)}
+              />
+            )}
+
+            <div className="flex items-center gap-2">
+              <FilterTab active={filter === 'all'} onClick={() => setFilter('all')}>
+                {t('suggestions_page.filters.all', { count: pillCounts.all })}
+              </FilterTab>
+              <FilterTab active={filter === 'read_next'} onClick={() => setFilter('read_next')}>
+                {t('suggestions_page.filters.read_next', { count: pillCounts.readNext })}
+              </FilterTab>
+              <FilterTab active={filter === 'buy'} onClick={() => setFilter('buy')}>
+                {t('suggestions_page.filters.buy', { count: pillCounts.buy })}
+              </FilterTab>
+              {/* Saved tab is only meaningful in default (mixed) mode. */}
+              {!scopedRunId && (
+                <FilterTab active={filter === 'saved'} onClick={() => setFilter('saved')}>
+                  {t('suggestions_page.filters.saved', { count: pillCounts.saved })}
+                </FilterTab>
+              )}
+            </div>
+
+            {activeRun && (
+              <div className="flex items-center gap-3 rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-950/40 px-4 py-3">
+                <svg className="h-4 w-4 animate-spin text-blue-600 dark:text-blue-400 flex-shrink-0" viewBox="0 0 24 24" fill="none">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" className="opacity-25" />
+                  <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+                </svg>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
+                    {t('suggestions_page.progress.title')}
+                  </p>
+                  <p className="text-xs text-blue-700 dark:text-blue-300">
+                    {activeEventCount > 0
+                      ? t('suggestions_page.progress.steps', { count: activeEventCount })
+                      : t('suggestions_page.progress.starting')}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {error ? (
+              <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-4 text-sm text-red-700 dark:text-red-300">
+                {error}
+              </div>
+            ) : filtered === null ? (
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                {[...Array(6)].map((_, i) => (
+                  <div key={i} className="space-y-2">
+                    <div className="aspect-[2/3] rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                    <div className="h-3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                    <div className="h-2 w-2/3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+                  </div>
+                ))}
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-700 p-8 text-center">
+                <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  {t(isSaved ? 'suggestions_page.saved_empty.title' : 'suggestions_page.empty.title')}
+                </p>
+                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  {t(isSaved ? 'suggestions_page.saved_empty.hint' : 'suggestions_page.empty.hint')}
+                </p>
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-4">
+                {filtered.map(s => (
+                  <SuggestionCard key={s.id} suggestion={s} onChanged={handleChanged} />
+                ))}
+              </div>
+            )}
+
+            <RecentRunsPanel
+              runs={recentRuns}
+              expanded={recentExpanded}
+              onToggle={() => setRecentExpanded(e => !e)}
+              activeRunId={scopedRunId}
+              onView={id => setScope(id)}
+              onRerun={run => openModal(run.steering ?? null)}
+            />
+          </>
         )}
       </div>
+
+      <CustomRequestModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSubmit={submitRun}
+        submitting={running}
+        initial={modalInitial}
+      />
     </>
   )
 }
@@ -282,5 +419,341 @@ function FilterTab({
     >
       {children}
     </button>
+  )
+}
+
+function UnavailableCard({ reason }: { reason: string | null }) {
+  const title =
+    reason === 'job_disabled'
+      ? 'AI suggestions are currently disabled'
+      : reason === 'no_provider'
+        ? 'No AI provider is configured'
+        : reason === 'not_opted_in'
+          ? "You haven't opted in to AI features"
+          : 'AI suggestions are not available'
+  const body =
+    reason === 'job_disabled' ? (
+      <>The site administrator has paused the AI suggestions job. Ask them to re-enable it from the admin settings.</>
+    ) : reason === 'no_provider' ? (
+      <>
+        An administrator needs to configure an AI provider under{' '}
+        <Link to="/admin/connections/ai" className="text-blue-600 dark:text-blue-400 hover:underline">
+          Connections → AI
+        </Link>{' '}
+        before suggestions can run.
+      </>
+    ) : reason === 'not_opted_in' ? (
+      <>
+        Enable AI features on your{' '}
+        <Link to="/profile" className="text-blue-600 dark:text-blue-400 hover:underline">
+          profile page
+        </Link>{' '}
+        to start getting book suggestions.
+      </>
+    ) : (
+      <>Suggestions can't run right now. Please check back later.</>
+    )
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6 text-center">
+      <p className="text-sm font-semibold text-gray-900 dark:text-white">{title}</p>
+      <p className="mt-2 text-sm text-gray-600 dark:text-gray-300 max-w-xl mx-auto">{body}</p>
+    </div>
+  )
+}
+
+// Relative-time formatter used by the banner + Recent runs panel. We prefer
+// "just now" / "3 days ago" over absolute timestamps when the run is recent
+// so the UI feels live; older runs fall back to a locale date.
+function relativeTime(iso: string | undefined): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (isNaN(then)) return ''
+  const diffMs = Date.now() - then
+  const mins = Math.floor(diffMs / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins} min${mins === 1 ? '' : 's'} ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs} hour${hrs === 1 ? '' : 's'} ago`
+  const days = Math.floor(hrs / 24)
+  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+// Palette classes echo the modal's chip colours so the banner and Recent
+// runs entries are visually traceable back to what the user asked for.
+const bannerChipClasses = {
+  indigo: 'bg-indigo-100 dark:bg-indigo-900/60 text-indigo-700 dark:text-indigo-300',
+  purple: 'bg-purple-100 dark:bg-purple-900/60 text-purple-700 dark:text-purple-300',
+  emerald: 'bg-emerald-100 dark:bg-emerald-900/60 text-emerald-700 dark:text-emerald-300',
+  amber: 'bg-amber-100 dark:bg-amber-900/60 text-amber-700 dark:text-amber-300',
+  gray: 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300',
+}
+
+function BannerChip({
+  palette,
+  children,
+  italic,
+}: {
+  palette: keyof typeof bannerChipClasses
+  children: React.ReactNode
+  italic?: boolean
+}) {
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-xs ${bannerChipClasses[palette]} ${italic ? 'italic' : ''}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+function SteeringBanner({
+  run,
+  onEdit,
+  onClear,
+}: {
+  run: SuggestionRunView | null
+  onEdit: () => void
+  onClear: () => void
+}) {
+  // Banner appears for both steered and unsteered scoped runs. For unsteered
+  // runs we just show a "Scheduled run" label so the scope is legible.
+  const steering = run?.steering
+  const isSteered = Boolean(
+    steering &&
+      ((steering.authors?.length ?? 0) > 0 ||
+        (steering.series?.length ?? 0) > 0 ||
+        (steering.genres?.length ?? 0) > 0 ||
+        (steering.tags?.length ?? 0) > 0 ||
+        (steering.notes ?? '').trim().length > 0),
+  )
+  return (
+    <div className="rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-950/40 px-4 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <svg
+              className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+            </svg>
+            <span className="text-sm font-semibold text-blue-900 dark:text-blue-100">
+              {isSteered ? 'Custom request' : 'Scheduled run'}
+              <span className="ml-1.5 font-normal text-blue-700/80 dark:text-blue-300/80">
+                · {relativeTime(run?.started_at)}
+              </span>
+            </span>
+          </div>
+          {isSteered && steering ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {(steering.authors?.length ?? 0) > 0 && (
+                <BannerChip palette="indigo">
+                  Authors: {steering.authors!.map(a => a.name).join(', ')}
+                </BannerChip>
+              )}
+              {(steering.series?.length ?? 0) > 0 && (
+                <BannerChip palette="purple">
+                  Series: {steering.series!.map(s => s.name).join(', ')}
+                </BannerChip>
+              )}
+              {(steering.genres?.length ?? 0) > 0 && (
+                <BannerChip palette="emerald">
+                  Genres: {steering.genres!.map(g => g.name).join(', ')}
+                </BannerChip>
+              )}
+              {(steering.tags?.length ?? 0) > 0 && (
+                <BannerChip palette="amber">
+                  Tags: {steering.tags!.map(tag => tag.name).join(', ')}
+                </BannerChip>
+              )}
+              {steering.notes && (
+                <BannerChip palette="gray" italic>
+                  "{steering.notes}"
+                </BannerChip>
+              )}
+            </div>
+          ) : (
+            <p className="mt-1.5 text-xs text-blue-700 dark:text-blue-300">
+              Showing the results of this scheduled run. Clear to return to the mixed pool.
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {isSteered && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="text-xs font-medium text-blue-700 dark:text-blue-300 hover:underline whitespace-nowrap"
+            >
+              Edit & re-run
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClear}
+            title="Clear scope"
+            className="p-1 -m-1 rounded text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100"
+            aria-label="Clear scope"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// truncate helps the Recent Runs summary chips stay one-line-ish without
+// destroying intent. Notes are already short in practice but may still need
+// clipping on narrow viewports.
+function truncate(s: string, max = 32): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s
+}
+
+function RecentRunsPanel({
+  runs,
+  expanded,
+  onToggle,
+  activeRunId,
+  onView,
+  onRerun,
+}: {
+  runs: SuggestionRunView[] | null
+  expanded: boolean
+  onToggle: () => void
+  activeRunId: string | null
+  onView: (id: string) => void
+  onRerun: (run: SuggestionRunView) => void
+}) {
+  const visibleRuns = useMemo(() => (runs ?? []).slice(0, 5), [runs])
+  return (
+    <div className="border-t border-gray-200 dark:border-gray-800 pt-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Recent runs</h3>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+        >
+          {expanded ? 'Collapse' : 'Expand'}
+        </button>
+      </div>
+      {expanded && (
+        <ul className="space-y-2">
+          {runs === null ? (
+            <li className="text-xs text-gray-400">Loading…</li>
+          ) : visibleRuns.length === 0 ? (
+            <li className="text-xs text-gray-400">No runs yet.</li>
+          ) : (
+            visibleRuns.map(run => {
+              const steering = run.steering
+              const isSteered = Boolean(
+                steering &&
+                  ((steering.authors?.length ?? 0) > 0 ||
+                    (steering.series?.length ?? 0) > 0 ||
+                    (steering.genres?.length ?? 0) > 0 ||
+                    (steering.tags?.length ?? 0) > 0 ||
+                    (steering.notes ?? '').trim().length > 0),
+              )
+              const isActive = run.id === activeRunId
+              const canView = run.status === 'completed'
+              const when = relativeTime(run.started_at)
+              const count = run.suggestion_count ?? 0
+              return (
+                <li
+                  key={run.id}
+                  className={
+                    isActive
+                      ? 'rounded-lg border border-blue-200 dark:border-blue-900 bg-blue-50/50 dark:bg-blue-950/20 px-3 py-2.5'
+                      : 'rounded-lg border border-gray-200 dark:border-gray-800 px-3 py-2.5'
+                  }
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={
+                            isSteered
+                              ? isActive
+                                ? 'text-xs font-semibold text-blue-900 dark:text-blue-100'
+                                : 'text-xs font-semibold text-gray-900 dark:text-white'
+                              : 'text-xs font-semibold text-gray-500 dark:text-gray-400'
+                          }
+                        >
+                          {isSteered ? 'Custom' : 'Scheduled'}
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          · {when}
+                          {run.status === 'running' ? ' · running…' : ` · ${count} suggestions`}
+                        </span>
+                      </div>
+                      {isSteered && steering && (
+                        <div className="mt-1.5 flex flex-wrap gap-1">
+                          {(steering.authors?.length ?? 0) > 0 && (
+                            <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${bannerChipClasses.indigo}`}>
+                              {steering.authors!.map(a => a.name).join(', ')}
+                            </span>
+                          )}
+                          {(steering.series?.length ?? 0) > 0 && (
+                            <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${bannerChipClasses.purple}`}>
+                              {steering.series!.map(s => s.name).join(', ')}
+                            </span>
+                          )}
+                          {(steering.genres?.length ?? 0) > 0 && (
+                            <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${bannerChipClasses.emerald}`}>
+                              {steering.genres!.map(g => g.name).join(', ')}
+                            </span>
+                          )}
+                          {(steering.tags?.length ?? 0) > 0 && (
+                            <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${bannerChipClasses.amber}`}>
+                              {steering.tags!.map(t => t.name).join(', ')}
+                            </span>
+                          )}
+                          {steering.notes && (
+                            <span className={`rounded-full px-1.5 py-0.5 text-[10px] italic ${bannerChipClasses.gray}`}>
+                              "{truncate(steering.notes, 28)}"
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 flex-shrink-0">
+                      {canView && !isActive && (
+                        <button
+                          type="button"
+                          onClick={() => onView(run.id)}
+                          className="text-xs font-medium text-gray-600 dark:text-gray-400 hover:underline"
+                        >
+                          View
+                        </button>
+                      )}
+                      {isSteered && (
+                        <button
+                          type="button"
+                          onClick={() => onRerun(run)}
+                          className={
+                            isActive
+                              ? 'text-xs font-medium text-blue-700 dark:text-blue-300 hover:underline'
+                              : 'text-xs font-medium text-gray-600 dark:text-gray-400 hover:underline'
+                          }
+                        >
+                          Re-run
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              )
+            })
+          )}
+        </ul>
+      )}
+    </div>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,25 @@ export interface ContributorResult {
   name: string
 }
 
+// MeSeriesResult — GET /api/v1/me/series, aggregated across the caller's libraries.
+export interface MeSeriesResult {
+  id: string
+  name: string
+  library_id: string
+  library_name: string
+}
+
+// MeTagResult — GET /api/v1/me/tags. `ambiguous` is true when another
+// accessible library has a tag with the same name; the UI appends the
+// library name to disambiguate.
+export interface MeTagResult {
+  id: string
+  name: string
+  library_id: string
+  library_name: string
+  ambiguous: boolean
+}
+
 export interface BookContributor {
   contributor_id: string
   name: string
@@ -575,6 +594,28 @@ export interface SuggestionRunView {
   estimated_cost_usd: number
   started_at: string
   finished_at?: string
+  suggestion_count?: number
+  steering?: SuggestionSteeringView | null
+}
+
+// Steering payload sent with POST /me/suggestions/run. All fields optional;
+// at least one must be non-empty for the server to accept it.
+export interface SuggestionSteeringInput {
+  author_ids?: string[]
+  series_ids?: string[]
+  genre_ids?: string[]
+  tag_ids?: string[]
+  notes?: string
+}
+
+// SuggestionSteeringView is the hydrated form returned on run reads: IDs
+// resolved to display names so the banner can render without extra fetches.
+export interface SuggestionSteeringView {
+  authors?: Array<{ id: string; name: string }>
+  series?: Array<{ id: string; name: string }>
+  genres?: Array<{ id: string; name: string }>
+  tags?: Array<{ id: string; name: string; library_id: string }>
+  notes?: string
 }
 
 // SuggestionRunEvent is one observable step in a pipeline run. `content`
@@ -597,6 +638,18 @@ export interface JobSummary {
   description: string
   kind: string
   enabled: boolean
+}
+
+// QuotaView is returned by GET /me/suggestions/quota. `available === false`
+// gates Run Now + sidebar visibility; `unavailable_reason` is one of
+// `job_disabled` / `no_provider` / `not_opted_in` when unavailable.
+export interface SuggestionQuotaView {
+  used: number
+  limit: number
+  resets_at?: string
+  unlimited: boolean
+  available: boolean
+  unavailable_reason: string | null
 }
 
 export interface AISuggestionsJobConfig {


### PR DESCRIPTION
- Adds `CustomRequestModal` for composing steered runs with author/series/genre/tag chips and free-form notes.
- Suggestions page surfaces a scoped-run banner, "Edit & re-run", and the Recent runs panel; profile/nav get minor touch-ups.