### PR TITLE
feat(m2m): align web with book ↔ library many-to-many

### DIFF
--- a/src/components/AddEditionModal.tsx
+++ b/src/components/AddEditionModal.tsx
@@ -94,9 +94,7 @@ export function AddEditionModal({ libraryId, bookId, edition, contributors = [],
     duration_hours:          existingSecs > 0 ? String(Math.floor(existingSecs / 3600)) : '',
     duration_minutes:        existingSecs > 0 ? String(Math.floor((existingSecs % 3600) / 60)) : '',
     page_count:              edition?.page_count != null ? String(edition.page_count) : '',
-    copy_count:              String(edition?.copy_count ?? 1),
     is_primary:              edition?.is_primary    ?? false,
-    acquired_at:             edition?.acquired_at   ?? new Date().toISOString().slice(0, 10),
   })
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -144,9 +142,7 @@ export function AddEditionModal({ libraryId, bookId, edition, contributors = [],
         isbn_13:                 !isAudio   ? form.isbn_13 : null,
         duration_seconds:        durationSecs || null,
         page_count:              !isAudio && form.page_count ? Number(form.page_count) : null,
-        copy_count:              form.copy_count ? Number(form.copy_count) : 1,
         is_primary:              form.is_primary,
-        acquired_at:             form.acquired_at || null,
       }
       const url = edition
         ? `/api/v1/libraries/${libraryId}/books/${bookId}/editions/${edition.id}`
@@ -296,19 +292,9 @@ export function AddEditionModal({ libraryId, bookId, edition, contributors = [],
             </div>
           )}
 
-          {/* Copies (physical only) + date acquired */}
-          <div className={`grid gap-3 ${isPhysical ? 'grid-cols-2' : 'grid-cols-1'}`}>
-            {isPhysical && (
-              <div>
-                <label className={labelCls}>Copies</label>
-                <input type="number" min="1" value={form.copy_count} onChange={e => setForm(f => ({ ...f, copy_count: e.target.value }))} className={inputCls} />
-              </div>
-            )}
-            <div>
-              <label className={labelCls}>Date acquired</label>
-              <input type="date" value={form.acquired_at} onChange={e => setForm(f => ({ ...f, acquired_at: e.target.value }))} className={inputCls} />
-            </div>
-          </div>
+          {/* Copy count + acquisition date were removed here with the M2M
+              refactor — both are now per-library properties (library_book_editions
+              junction). Per-library copy UI will return as a follow-up feature. */}
 
           <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
             <input type="checkbox" checked={form.is_primary} onChange={e => setForm(f => ({ ...f, is_primary: e.target.checked }))}

--- a/src/components/EditBookModal.tsx
+++ b/src/components/EditBookModal.tsx
@@ -402,8 +402,7 @@ export default function EditBookModal({ libraryId, book, onClose, onSaved, initi
                   e.narrator         ? { label: 'Narrator',   value: e.narrator } : null,
                   e.isbn_13          ? { label: 'ISBN-13',    value: e.isbn_13 } : null,
                   e.isbn_10          ? { label: 'ISBN-10',    value: e.isbn_10 } : null,
-                  e.copy_count > 1   ? { label: 'Copies',     value: String(e.copy_count) } : null,
-                  e.acquired_at      ? { label: 'Acquired',   value: e.acquired_at } : null,
+                  // Copies and Acquired moved to per-library display — follow-up work.
                 ].filter(Boolean) as Array<{ label: string; value: string }>
 
                 return (

--- a/src/pages/libraries/BookPage.tsx
+++ b/src/pages/libraries/BookPage.tsx
@@ -578,13 +578,12 @@ function EditionCard({ edition: initialEdition, libraryId, bookId, onEdit, onDel
     edition.publisher        ? { label: 'Publisher',  value: edition.publisher } : null,
     edition.language         ? { label: 'Language',   value: edition.language.toUpperCase() } : null,
     edition.publish_date     ? { label: 'Published',  value: edition.publish_date } : null,
-    edition.acquired_at      ? { label: 'Acquired',   value: edition.acquired_at } : null,
     edition.isbn_13          ? { label: 'ISBN-13',    value: <span className="font-mono">{edition.isbn_13}</span> } : null,
     edition.isbn_10          ? { label: 'ISBN-10',    value: <span className="font-mono">{edition.isbn_10}</span> } : null,
     edition.page_count != null    ? { label: 'Pages',    value: `${edition.page_count}` } : null,
     edition.duration_seconds != null ? { label: 'Duration', value: `${Math.round(edition.duration_seconds / 3600 * 10) / 10} hrs` } : null,
     edition.narrator         ? { label: 'Narrator',   value: edition.narrator } : null,
-    edition.copy_count > 1   ? { label: 'Copies',     value: <span className="text-blue-600 dark:text-blue-400">{edition.copy_count}</span> } : null,
+    // Copies + Acquired moved to per-library display — follow-up work under M2M.
   ].filter(Boolean)
 
   return (
@@ -885,8 +884,8 @@ function MergedMetadataModal({ book, editions, libraryId, bookId, onClose, onApp
             body: JSON.stringify({
               format: primaryEdition.format, edition_name: primaryEdition.edition_name,
               narrator: primaryEdition.narrator, is_primary: primaryEdition.is_primary,
-              copy_count: primaryEdition.copy_count, duration_seconds: primaryEdition.duration_seconds,
-              description: primaryEdition.description, acquired_at: primaryEdition.acquired_at,
+              duration_seconds: primaryEdition.duration_seconds,
+              description: primaryEdition.description,
               language: pick('language', primaryEdition.language ?? ''),
               publisher: pick('publisher', primaryEdition.publisher ?? ''),
               publish_date: pick('publish_date', primaryEdition.publish_date ?? ''),

--- a/src/pages/libraries/LibraryPage.tsx
+++ b/src/pages/libraries/LibraryPage.tsx
@@ -455,7 +455,6 @@ function AddBookModal({ libraryId, mediaTypes, onClose, onSaved, onDuplicate, in
     duration_minutes: '',
     narrator: '',
     is_primary: true,
-    acquired_at: new Date().toISOString().slice(0, 10),
   })
 
   const [error, setError] = useState<string | null>(null)
@@ -753,7 +752,6 @@ function AddBookModal({ libraryId, mediaTypes, onClose, onSaved, onDuplicate, in
           duration_seconds: durationSecs || null,
           narrator:         isAudio ? edition.narrator : null,
           is_primary:       edition.is_primary,
-          acquired_at:      edition.acquired_at || null,
         }
       }
       const book = await callApi<Book>(`/api/v1/libraries/${libraryId}/books`, {
@@ -1314,11 +1312,7 @@ function AddBookModal({ libraryId, mediaTypes, onClose, onSaved, onDuplicate, in
                       </div>
                     )}
 
-                    {/* Date acquired (all formats) */}
-                    <div>
-                      <label className={labelCls}>Date acquired</label>
-                      <input type="date" value={edition.acquired_at} onChange={e => setEdition(d => ({ ...d, acquired_at: e.target.value }))} className={inputCls} />
-                    </div>
+                    {/* Date acquired moved to per-library tracking under M2M — follow-up. */}
                   </div>
                   )
                 })()}

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,15 +98,24 @@ export interface BookShelfRef {
   name: string
 }
 
+export interface BookLibraryRef {
+  id: string
+  name: string
+}
+
 export interface Book {
   id: string
-  library_id: string
+  // library_id is the first library holding this book (picked by the API
+  // from the library_books junction). Null when the book is floating — i.e.
+  // not in any library (e.g. a suggestion-only book). Prefer `libraries`
+  // when you need the full set.
+  library_id: string | null
+  libraries?: BookLibraryRef[]
   title: string
   subtitle: string
   media_type_id: string
   media_type: string
   description: string
-  added_by: string | null
   created_at: string
   updated_at: string
   contributors: BookContributor[]
@@ -154,12 +163,12 @@ export interface BookEdition {
   publish_date: string | null
   isbn_10: string
   isbn_13: string
-  copy_count: number
   description: string
   duration_seconds: number | null
   page_count: number | null
   is_primary: boolean
-  acquired_at: string | null
+  // copy_count and acquired_at used to live here; they're now per-library
+  // (tracked in library_book_editions). Future work: per-library copy UI.
   created_at: string
   updated_at: string
   files: EditionFile[]


### PR DESCRIPTION
- \`Book.library_id\` → nullable (picked primary from the new junction, null for floating books); new optional \`libraries[]\` field for the full list. \`BookEdition\` drops \`copy_count\` and \`acquired_at\` — both are per-library now.
- Removes the per-edition Copies + Acquired display and form controls on BookPage, EditBookModal, AddEditionModal, LibraryPage. Per-library copy UI returns as follow-up work.