### PR TITLE
feat(suggestions): polish detail page + 30-day window on list

### DIFF
--- a/src/pages/BookDetailPage.tsx
+++ b/src/pages/BookDetailPage.tsx
@@ -6,7 +6,7 @@ import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useAuth, ApiError } from '../auth/AuthContext'
 import { useToast } from '../components/Toast'
 import BookCover from '../components/BookCover'
-import type { Book, BookEdition, Library } from '../types'
+import type { Book, BookEdition, Library, SuggestionView } from '../types'
 
 // BookDetailPage renders a work-level book detail view keyed on book id alone
 // (no library in the URL), suitable for suggestion-backed books that may not
@@ -20,9 +20,11 @@ export default function BookDetailPage() {
 
   const [book, setBook] = useState<Book | null>(null)
   const [editions, setEditions] = useState<BookEdition[]>([])
+  const [suggestions, setSuggestions] = useState<SuggestionView[]>([])
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [libraryPickerOpen, setLibraryPickerOpen] = useState(false)
+  const [blockOpen, setBlockOpen] = useState(false)
 
   const load = useCallback(async () => {
     if (!bookId) return
@@ -36,6 +38,12 @@ export default function BookDetailPage() {
       setBook(b)
       const eds = await callApi<BookEdition[]>(`/api/v1/books/${bookId}/editions`)
       setEditions(eds ?? [])
+      // Look up any suggestions the user has for this book. Used to surface
+      // "Remove suggestion" and "Block" actions — the detail page is also
+      // reachable directly (no suggestion context), so these actions only
+      // show when a matching suggestion exists.
+      const ss = await callApi<SuggestionView[]>(`/api/v1/me/suggestions?book_id=${bookId}`)
+      setSuggestions(ss ?? [])
     } catch (err) {
       if (err instanceof ApiError && err.status === 404) {
         navigate('/suggestions', { replace: true })
@@ -95,6 +103,65 @@ export default function BookDetailPage() {
   // book's "no library yet" state. Users can re-enrich after adding the
   // book to a library.
 
+  const removeSuggestion = async () => {
+    if (suggestions.length === 0) return
+    setBusy(true)
+    try {
+      // Remove every matching suggestion row — typically one, but a user
+      // who got both a buy and a read_next for the same book gets a clean
+      // slate.
+      for (const s of suggestions) {
+        await callApi(`/api/v1/me/suggestions/${s.id}`, { method: 'DELETE' })
+      }
+      showToast('Suggestion removed', { variant: 'success' })
+      navigate('/suggestions')
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to remove suggestion', { variant: 'error' })
+      setBusy(false)
+    }
+  }
+
+  const refreshMetadata = async () => {
+    if (!bookId) return
+    setBusy(true)
+    try {
+      await callApi(`/api/v1/books/${bookId}/enrich`, { method: 'POST' })
+      showToast('Metadata refresh queued', { variant: 'success' })
+      // Give the worker a moment to start, then reload so new fields appear.
+      setTimeout(load, 2000)
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to queue refresh', { variant: 'error' })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const blockSuggestion = async (scope: 'book' | 'author') => {
+    if (suggestions.length === 0) return
+    setBusy(true)
+    setBlockOpen(false)
+    try {
+      // The block endpoint is keyed by suggestion id (it pulls title/author/
+      // isbn out of the suggestion for the blocklist row). Blocking any one
+      // of the user's matching suggestions blocks the work; the server-side
+      // block also clears out related suggestions.
+      await callApi(`/api/v1/me/suggestions/${suggestions[0].id}/block`, {
+        method: 'POST',
+        body: JSON.stringify({ scope }),
+      })
+      showToast(
+        scope === 'book'
+          ? 'Blocked this book'
+          : `Blocked anything by ${suggestions[0].author ?? 'this author'}`,
+        { variant: 'success' },
+      )
+      navigate('/suggestions')
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to block', { variant: 'error' })
+      setBusy(false)
+    }
+  }
+
   const addToLibrary = async (libraryID: string) => {
     if (!bookId) return
     setBusy(true)
@@ -143,16 +210,47 @@ export default function BookDetailPage() {
 
         {/* ── Right: details + actions ── */}
         <div className="flex-1 min-w-0 space-y-5">
-          <div>
-            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">{book.title}</h1>
-            {book.subtitle && (
-              <p className="mt-1 text-base text-gray-600 dark:text-gray-400">{book.subtitle}</p>
-            )}
-            {book.contributors && book.contributors.length > 0 && (
-              <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
-                {book.contributors.filter(c => c.role === 'author').map(c => c.name).join(', ')}
-              </p>
-            )}
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">{book.title}</h1>
+              {book.subtitle && (
+                <p className="mt-1 text-base text-gray-600 dark:text-gray-400">{book.subtitle}</p>
+              )}
+              {book.contributors && book.contributors.length > 0 && (
+                <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+                  {book.contributors.filter(c => c.role === 'author').map(c => c.name).join(', ')}
+                </p>
+              )}
+            </div>
+            {/* Icon row — matches BookPage's edition header style. Delete
+                only surfaces when the user actually has a suggestion for
+                this book; it deletes the suggestion row(s). */}
+            <div className="flex items-center gap-1 flex-shrink-0">
+              <button
+                type="button"
+                onClick={refreshMetadata}
+                disabled={busy}
+                title="Refresh metadata"
+                className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              </button>
+              {suggestions.length > 0 && (
+                <button
+                  type="button"
+                  onClick={removeSuggestion}
+                  disabled={busy}
+                  title="Delete suggestion"
+                  className="p-1.5 rounded-md text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              )}
+            </div>
           </div>
 
           {book.description && (
@@ -189,6 +287,48 @@ export default function BookDetailPage() {
               >
                 Find where to buy →
               </a>
+            )}
+            {/* Block lives as a dropdown — rarer action, benefits from a
+                labelled control over an icon. The trash icon above covers
+                the more common "Remove suggestion" case. */}
+            {suggestions.length > 0 && (
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setBlockOpen(o => !o)}
+                  disabled={busy}
+                  className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+                >
+                  Block ▾
+                </button>
+                {blockOpen && (
+                  <div className="absolute left-0 z-20 mt-1 w-56 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg py-1">
+                    <button
+                      type="button"
+                      onClick={() => blockSuggestion('book')}
+                      className="block w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200"
+                    >
+                      Block this book
+                    </button>
+                    {suggestions[0].author && (
+                      <button
+                        type="button"
+                        onClick={() => blockSuggestion('author')}
+                        className="block w-full text-left px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200"
+                      >
+                        Block by {suggestions[0].author}
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setBlockOpen(false)}
+                      className="block w-full text-left px-3 py-2 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                )}
+              </div>
             )}
           </div>
 

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -56,19 +56,23 @@ export default function SuggestionsPage() {
   // Track the last-seen running run so we can detect the running→completed
   // transition, refresh items, and auto-scope to it.
   const lastRunningIdRef = useRef<string | null>(null)
+  // Default the mixed view to the last 30 days so old never-actioned
+  // suggestions don't stack up indefinitely. "Show older" flips this off.
+  const [showOlder, setShowOlder] = useState(false)
 
   const loadMixed = useCallback(() => {
     setError(null)
+    const window = showOlder ? '' : '&since=30d'
     Promise.all([
-      callApi<SuggestionView[]>('/api/v1/me/suggestions?status=new'),
-      callApi<SuggestionView[]>('/api/v1/me/suggestions?status=interested'),
+      callApi<SuggestionView[]>(`/api/v1/me/suggestions?status=new${window}`),
+      callApi<SuggestionView[]>(`/api/v1/me/suggestions?status=interested${window}`),
     ])
       .then(([fresh, saved]) => {
         setNewItems(fresh ?? [])
         setSavedItems(saved ?? [])
       })
       .catch(err => setError(err instanceof ApiError ? err.message : t('errors.failed_to_load', { ns: 'common' })))
-  }, [callApi, t])
+  }, [callApi, t, showOlder])
 
   const loadScoped = useCallback((runId: string) => {
     setError(null)
@@ -307,7 +311,7 @@ export default function SuggestionsPage() {
               />
             )}
 
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <FilterTab active={filter === 'all'} onClick={() => setFilter('all')}>
                 {t('suggestions_page.filters.all', { count: pillCounts.all })}
               </FilterTab>
@@ -322,6 +326,18 @@ export default function SuggestionsPage() {
                 <FilterTab active={filter === 'saved'} onClick={() => setFilter('saved')}>
                   {t('suggestions_page.filters.saved', { count: pillCounts.saved })}
                 </FilterTab>
+              )}
+              {/* The 30-day window applies to the mixed pool (new + saved),
+                  not to a scoped-run view — there, users want every item
+                  the run produced regardless of age. */}
+              {!scopedRunId && (
+                <button
+                  type="button"
+                  onClick={() => setShowOlder(o => !o)}
+                  className="ml-auto text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 underline underline-offset-2"
+                >
+                  {showOlder ? 'Last 30 days only' : 'Show older suggestions'}
+                </button>
               )}
             </div>
 


### PR DESCRIPTION
- Suggestions list defaults to the last 30 days with a "Show older suggestions" toggle; scoped-run views are never windowed.
- BookDetailPage gets refresh-metadata + delete-suggestion icons in the header (matching BookPage's edition icon style) plus the existing Block dropdown. Looks up \`/me/suggestions?book_id=X\` to decide when to show the suggestion-scoped actions.