### PR TITLE
feat(jobs): unified JobsPage + react-js-cron editor (PR 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^17.0.4",
+        "react-js-cron": "^6.0.2",
         "react-router-dom": "^7.14.0"
       },
       "devDependencies": {
@@ -32,6 +33,99 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4"
+      }
+    },
+    "node_modules/@ant-design/colors": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
+      "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.2.tgz",
+      "integrity": "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/unitless": "^0.7.5",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1",
+        "csstype": "^3.1.3",
+        "stylis": "^4.3.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/cssinjs-utils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.2.tgz",
+      "integrity": "sha512-5fTHQ158jJJ5dC/ECeyIdZUzKxE/mpEMRZxthyG1sw/AKRHKgJBg00Yi6ACVXgycdje7KahRNvNET/uBccwCnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/cssinjs": "^2.1.2",
+        "@babel/runtime": "^7.23.2",
+        "@rc-component/util": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@ant-design/fast-color": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
+      "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@ant-design/icons": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.1.tgz",
+      "integrity": "sha512-AMT4N2y++TZETNHiM77fs4a0uPVCJGuL5MTonk13Pvv7UN7sID1cNEZOc1qNqx6zLKAOilTEFAdAoAFKa0U//Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/colors": "^8.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/icons-svg": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
+      "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
+      "license": "MIT"
+    },
+    "node_modules/@ant-design/react-slick": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
+      "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "clsx": "^2.1.1",
+        "json2mq": "^0.2.0",
+        "throttle-debounce": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -65,6 +159,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -283,29 +378,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -316,6 +388,18 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -603,6 +687,719 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rc-component/async-validator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
+      "integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.4"
+      },
+      "engines": {
+        "node": ">=14.x"
+      }
+    },
+    "node_modules/@rc-component/cascader": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
+      "integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/select": "~1.6.0",
+        "@rc-component/tree": "~1.2.0",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/checkbox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
+      "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/collapse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
+      "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/color-picker": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.1.tgz",
+      "integrity": "sha512-OHaCHLHszCegdXmIq2ZRIZBN/EtpT6Wm8SG/gpzLATHbVKc/avvuKi+zlOuk05FTWvgaMmpxAko44uRJ3M+2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/context": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
+      "integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/dialog": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
+      "integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.3",
+        "@rc-component/portal": "^2.1.0",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/drawer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
+      "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.1.3",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/dropdown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
+      "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.11.0",
+        "react-dom": ">=16.11.0"
+      }
+    },
+    "node_modules/@rc-component/form": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.1.tgz",
+      "integrity": "sha512-8O7TB55Fi2mWIGvSnwZjk8jFqVNYyKDAswglwGShcbndxqzKz4cHwNtNaLjZlAeRge9wcB0LL8IWsC/Bl18raQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/async-validator": "^5.1.0",
+        "@rc-component/util": "^1.6.2",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/image": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.9.0.tgz",
+      "integrity": "sha512-khF7w7xkBH5B1bsBcI1FSUZdkyd1aqpl2eYyILCqCzzQH3XdfehGUaZTnptyaJJfs09/R5hv9jXWyazOMFIClQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/portal": "^2.1.2",
+        "@rc-component/util": "^1.10.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/input": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
+      "integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/input-number": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
+      "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/mini-decimal": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mentions": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
+      "integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/input": "~1.1.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/textarea": "~1.1.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/menu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
+      "integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mini-decimal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.3.tgz",
+      "integrity": "sha512-bk/FJ09fLf+NLODMAFll6CfYrHPBioTedhW6lxDBuuWucJEqFUd4l/D/5JgIi3dina6sYahB8iuPAZTNz2pMxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@rc-component/motion": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.2.tgz",
+      "integrity": "sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mutate-observer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
+      "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/notification": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
+      "integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/overflow": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.1.tgz",
+      "integrity": "sha512-syfmgAABaHCnCDzPwHZ/2tuvIcpOO3jefYZMmfkN+pmo8HKTzsfhS57vxo4ksPdN0By+uWVJhJWNFozNBxi2eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/pagination": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
+      "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/picker": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.1.tgz",
+      "integrity": "sha512-9FBYYsvH3HMLICaPDA/1Th5FLaDkFa7qAtangIdlhKb3ZALaR745e9PsOhheJb6asS4QXc12ffiAcjdkZ4C5/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/trigger": "^3.6.15",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
+      "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/progress": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
+      "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/qrcode": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
+      "integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/rate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
+      "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/resize-observer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
+      "integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/segmented": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
+      "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/select": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.15.tgz",
+      "integrity": "sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/slider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
+      "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/steps": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
+      "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/switch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
+      "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/table": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
+      "integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/context": "^2.0.1",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.1.0",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tabs": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
+      "integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/dropdown": "~1.0.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/motion": "^1.1.3",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/textarea": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
+      "integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/input": "~1.1.0",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tooltip": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+      "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/trigger": "^3.7.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tour": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
+      "integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.7.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tree": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.4.tgz",
+      "integrity": "sha512-5Gli43+m4R7NhpYYz3Z61I6LOw9yI6CNChxgVtvrO6xB1qML7iE6QMLVMB3+FTjo2yF6uFdAHtqWPECz/zbX5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/util": "^1.8.1",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/tree-select": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
+      "integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/select": "~1.6.0",
+        "@rc-component/tree": "~1.2.0",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/trigger": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
+      "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/resize-observer": "^1.1.1",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/upload": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
+      "integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/util": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.10.1.tgz",
+      "integrity": "sha512-q++9S6rUa5Idb/xIBNz6jtvumw5+O5YV5V0g4iK9mn9jWs4oGJheE3ZN1kAnE723AXyaD8v95yeOASmdk8Jnng==",
+      "license": "MIT",
+      "dependencies": {
+        "is-mobile": "^5.0.0",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/virtual-list": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
+      "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.0",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1195,6 +1992,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1205,6 +2003,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1264,6 +2063,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -1546,6 +2346,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1594,6 +2395,71 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/antd": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-6.3.6.tgz",
+      "integrity": "sha512-zdCYjusrTUn4gNxEg4PH8MWlfuXYbKfuGOkjgZ0Rg6DpWbIVmG/MwvsZ5yvG6z3Y6UI/gzYpaQ82iTt4KdbeaA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ant-design/colors": "^8.0.1",
+        "@ant-design/cssinjs": "^2.1.2",
+        "@ant-design/cssinjs-utils": "^2.1.2",
+        "@ant-design/fast-color": "^3.0.1",
+        "@ant-design/icons": "^6.1.1",
+        "@ant-design/react-slick": "~2.0.0",
+        "@babel/runtime": "^7.28.4",
+        "@rc-component/cascader": "~1.14.0",
+        "@rc-component/checkbox": "~2.0.0",
+        "@rc-component/collapse": "~1.2.0",
+        "@rc-component/color-picker": "~3.1.1",
+        "@rc-component/dialog": "~1.8.4",
+        "@rc-component/drawer": "~1.4.2",
+        "@rc-component/dropdown": "~1.0.2",
+        "@rc-component/form": "~1.8.0",
+        "@rc-component/image": "~1.9.0",
+        "@rc-component/input": "~1.1.2",
+        "@rc-component/input-number": "~1.6.2",
+        "@rc-component/mentions": "~1.6.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/motion": "^1.3.2",
+        "@rc-component/mutate-observer": "^2.0.1",
+        "@rc-component/notification": "~1.2.0",
+        "@rc-component/pagination": "~1.2.0",
+        "@rc-component/picker": "~1.9.1",
+        "@rc-component/progress": "~1.0.2",
+        "@rc-component/qrcode": "~1.1.1",
+        "@rc-component/rate": "~1.0.1",
+        "@rc-component/resize-observer": "^1.1.2",
+        "@rc-component/segmented": "~1.3.0",
+        "@rc-component/select": "~1.6.15",
+        "@rc-component/slider": "~1.0.1",
+        "@rc-component/steps": "~1.2.2",
+        "@rc-component/switch": "~1.0.3",
+        "@rc-component/table": "~1.9.1",
+        "@rc-component/tabs": "~1.7.0",
+        "@rc-component/textarea": "~1.1.2",
+        "@rc-component/tooltip": "~1.4.0",
+        "@rc-component/tour": "~2.3.0",
+        "@rc-component/tree": "~1.2.4",
+        "@rc-component/tree-select": "~1.8.0",
+        "@rc-component/trigger": "^3.9.0",
+        "@rc-component/upload": "~1.1.0",
+        "@rc-component/util": "^1.10.1",
+        "clsx": "^2.1.1",
+        "dayjs": "^1.11.11",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "throttle-debounce": "^5.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ant-design"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/argparse": {
@@ -1654,6 +2520,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1716,6 +2583,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1734,6 +2610,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -1791,8 +2673,14 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1894,6 +2782,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2281,6 +3170,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -2371,6 +3261,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2441,6 +3337,15 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -2952,6 +3857,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3013,6 +3919,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3022,6 +3929,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3054,6 +3962,26 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-js-cron": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-6.0.2.tgz",
+      "integrity": "sha512-JLrOujYZhfQqnIZk5KGkkzUdK+QuSJBdGS9xRnifdWg8FMgRLod1INnU4vsQxcdjYCylEF6oVfh5WnRDhZ58+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "antd": ">=6.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-router": {
@@ -3151,6 +4079,15 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -3200,6 +4137,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3212,6 +4155,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3245,6 +4194,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
+      "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22"
       }
     },
     "node_modules/tinyglobby": {
@@ -3310,6 +4268,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3405,6 +4364,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3554,6 +4514,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
       "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.0"
       }
@@ -49,6 +50,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.2.tgz",
       "integrity": "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -68,6 +70,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.2.tgz",
       "integrity": "sha512-5fTHQ158jJJ5dC/ECeyIdZUzKxE/mpEMRZxthyG1sw/AKRHKgJBg00Yi6ACVXgycdje7KahRNvNET/uBccwCnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/cssinjs": "^2.1.2",
         "@babel/runtime": "^7.23.2",
@@ -83,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
       "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.x"
       }
@@ -92,6 +96,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.1.tgz",
       "integrity": "sha512-AMT4N2y++TZETNHiM77fs4a0uPVCJGuL5MTonk13Pvv7UN7sID1cNEZOc1qNqx6zLKAOilTEFAdAoAFKa0U//Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^8.0.0",
         "@ant-design/icons-svg": "^4.4.0",
@@ -110,13 +115,15 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
       "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ant-design/react-slick": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
       "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "clsx": "^2.1.1",
@@ -159,7 +166,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -378,6 +384,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -393,13 +422,15 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -694,6 +725,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
       "integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.4"
       },
@@ -706,6 +738,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
       "integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -722,6 +755,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
       "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -736,6 +770,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
       "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/motion": "^1.1.4",
@@ -752,6 +787,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.1.tgz",
       "integrity": "sha512-OHaCHLHszCegdXmIq2ZRIZBN/EtpT6Wm8SG/gpzLATHbVKc/avvuKi+zlOuk05FTWvgaMmpxAko44uRJ3M+2pg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.1",
         "@rc-component/util": "^1.3.0",
@@ -767,6 +803,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
       "integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0"
       },
@@ -780,6 +817,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
       "integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.3",
         "@rc-component/portal": "^2.1.0",
@@ -796,6 +834,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
       "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.1.3",
@@ -812,6 +851,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
       "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.0.0",
         "@rc-component/util": "^1.2.1",
@@ -827,6 +867,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.1.tgz",
       "integrity": "sha512-8O7TB55Fi2mWIGvSnwZjk8jFqVNYyKDAswglwGShcbndxqzKz4cHwNtNaLjZlAeRge9wcB0LL8IWsC/Bl18raQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/async-validator": "^5.1.0",
         "@rc-component/util": "^1.6.2",
@@ -845,6 +886,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.9.0.tgz",
       "integrity": "sha512-khF7w7xkBH5B1bsBcI1FSUZdkyd1aqpl2eYyILCqCzzQH3XdfehGUaZTnptyaJJfs09/R5hv9jXWyazOMFIClQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/portal": "^2.1.2",
@@ -861,6 +903,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
       "integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.4.0",
         "clsx": "^2.1.1"
@@ -875,6 +918,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
       "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/mini-decimal": "^1.0.1",
         "@rc-component/util": "^1.4.0",
@@ -890,6 +934,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
       "integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/menu": "~1.2.0",
@@ -908,6 +953,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
       "integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/overflow": "^1.0.0",
@@ -925,6 +971,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.3.tgz",
       "integrity": "sha512-bk/FJ09fLf+NLODMAFll6CfYrHPBioTedhW6lxDBuuWucJEqFUd4l/D/5JgIi3dina6sYahB8iuPAZTNz2pMxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0"
       },
@@ -937,6 +984,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.2.tgz",
       "integrity": "sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0",
         "clsx": "^2.1.1"
@@ -951,6 +999,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
       "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -967,6 +1016,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
       "integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/util": "^1.2.1",
@@ -985,6 +1035,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.1.tgz",
       "integrity": "sha512-syfmgAABaHCnCDzPwHZ/2tuvIcpOO3jefYZMmfkN+pmo8HKTzsfhS57vxo4ksPdN0By+uWVJhJWNFozNBxi2eA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/resize-observer": "^1.0.1",
@@ -1001,6 +1052,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
       "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1015,6 +1067,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.1.tgz",
       "integrity": "sha512-9FBYYsvH3HMLICaPDA/1Th5FLaDkFa7qAtangIdlhKb3ZALaR745e9PsOhheJb6asS4QXc12ffiAcjdkZ4C5/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -1053,6 +1106,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
       "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -1070,6 +1124,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
       "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -1084,6 +1139,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
       "integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7"
       },
@@ -1100,6 +1156,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
       "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1117,6 +1174,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
       "integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -1130,6 +1188,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
       "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/motion": "^1.1.4",
@@ -1146,6 +1205,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.15.tgz",
       "integrity": "sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/trigger": "^3.0.0",
@@ -1166,6 +1226,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
       "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1183,6 +1244,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
       "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -1200,6 +1262,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
       "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1214,6 +1277,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
       "integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/context": "^2.0.1",
         "@rc-component/resize-observer": "^1.0.0",
@@ -1234,6 +1298,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
       "integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/dropdown": "~1.0.0",
         "@rc-component/menu": "~1.2.0",
@@ -1255,6 +1320,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
       "integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -1271,6 +1337,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
       "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.7.1",
         "@rc-component/util": "^1.3.0",
@@ -1286,6 +1353,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
       "integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/portal": "^2.2.0",
         "@rc-component/trigger": "^3.0.0",
@@ -1305,6 +1373,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.4.tgz",
       "integrity": "sha512-5Gli43+m4R7NhpYYz3Z61I6LOw9yI6CNChxgVtvrO6xB1qML7iE6QMLVMB3+FTjo2yF6uFdAHtqWPECz/zbX5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/util": "^1.8.1",
@@ -1324,6 +1393,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
       "integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -1340,6 +1410,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
       "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.2.0",
@@ -1360,6 +1431,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
       "integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1374,6 +1446,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.10.1.tgz",
       "integrity": "sha512-q++9S6rUa5Idb/xIBNz6jtvumw5+O5YV5V0g4iK9mn9jWs4oGJheE3ZN1kAnE723AXyaD8v95yeOASmdk8Jnng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-mobile": "^5.0.0",
         "react-is": "^18.2.0"
@@ -1388,6 +1461,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
       "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@rc-component/resize-observer": "^1.0.1",
@@ -1992,7 +2066,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2003,7 +2076,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2063,7 +2135,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2346,7 +2417,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2520,7 +2590,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2588,6 +2657,7 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2616,7 +2686,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2782,7 +2853,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3170,7 +3240,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -3265,7 +3334,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
       "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3343,6 +3413,7 @@
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-convert": "^0.2.0"
       }
@@ -3857,7 +3928,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3919,7 +3989,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3929,7 +3998,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3968,7 +4036,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-js-cron": {
       "version": "6.0.2",
@@ -4084,6 +4153,7 @@
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -4141,7 +4211,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -4160,7 +4231,8 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -4201,6 +4273,7 @@
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
       "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       }
@@ -4268,7 +4341,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4364,7 +4436,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4514,7 +4585,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-i18next": "^17.0.4",
+    "react-js-cron": "^6.0.2",
     "react-router-dom": "^7.14.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import ContributorPage from './pages/libraries/ContributorPage'
 import ImportPage from './pages/import/ImportPage'
 import UsersPage from './pages/admin/UsersPage'
 import JobsPage from './pages/jobs/JobsPage'
+import JobKindPage from './pages/jobs/JobKindPage'
+import JobsHistoryPage from './pages/jobs/JobsHistoryPage'
 import SettingsLayout from './pages/admin/SettingsLayout'
 import MetadataPage from './pages/admin/settings/MetadataPage'
 import MediaManagementPage from './pages/admin/settings/MediaManagementPage'
@@ -63,7 +65,9 @@ function AppRoutes() {
                   <Route path="media-types"       element={<MediaTypesPage />} />
                   <Route path="profiles"          element={<ProfilesPage />} />
                   <Route path="general"           element={<GeneralPage />} />
-                  <Route path="jobs"             element={<JobsPage />} />
+                  <Route path="jobs"              element={<JobsPage />} />
+                  <Route path="jobs/history"       element={<JobsHistoryPage />} />
+                  <Route path="jobs/:kind"         element={<JobKindPage />} />
                 </Route>
               </Route>
 

--- a/src/components/RunDetailPanel.tsx
+++ b/src/components/RunDetailPanel.tsx
@@ -76,6 +76,17 @@ export default function RunDetailPanel({ endpoint, hideSummary }: RunDetailPanel
   }, [detail])
 
   if (error) {
+    // Expanding an orchestrator/dispatcher umbrella row (e.g. the admin
+    // Run Now wrapper around per-user fanout) has no associated run
+    // record — GetRun 404s with "run not found". Render a neutral
+    // placeholder instead of a red error, since nothing actually failed.
+    if (/not found/i.test(error)) {
+      return (
+        <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-3 text-sm text-gray-500 dark:text-gray-400">
+          This entry is a dispatcher — the per-user suggestion runs it queued each have their own row below.
+        </div>
+      )
+    }
     return (
       <div className="rounded-md border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-700 dark:text-red-300">
         {error}

--- a/src/pages/jobs/AISuggestionsJobCard.tsx
+++ b/src/pages/jobs/AISuggestionsJobCard.tsx
@@ -6,27 +6,6 @@ import { useAuth, ApiError } from '../../auth/AuthContext'
 import { useToast } from '../../components/Toast'
 import type { AISuggestionsJobConfig } from '../../types'
 
-// INTERVAL_PRESETS are friendly labels over minute counts. Custom values stay
-// editable in the raw input so admins can pick anything.
-const INTERVAL_PRESETS: Array<{ minutes: number; label: string }> = [
-  { minutes: 60,       label: 'Every hour' },
-  { minutes: 6 * 60,   label: 'Every 6 hours' },
-  { minutes: 12 * 60,  label: 'Every 12 hours' },
-  { minutes: 24 * 60,  label: 'Daily' },
-  { minutes: 3 * 24 * 60, label: 'Every 3 days' },
-  { minutes: 7 * 24 * 60, label: 'Weekly' },
-]
-
-function formatInterval(minutes: number): string {
-  const p = INTERVAL_PRESETS.find(x => x.minutes === minutes)
-  if (p) return p.label
-  if (minutes <= 0) return 'Disabled'
-  const h = minutes / 60
-  if (h % 24 === 0 && h > 0) return `Every ${h / 24} day${h / 24 === 1 ? '' : 's'}`
-  if (minutes % 60 === 0) return `Every ${h} hour${h === 1 ? '' : 's'}`
-  return `Every ${minutes} minutes`
-}
-
 interface AISuggestionsJobCardProps {
   // Fires after a successful Run now so the parent can reload the jobs list
   // and surface the new run immediately.
@@ -150,7 +129,7 @@ export default function AISuggestionsJobCard({ onRunKicked }: AISuggestionsJobCa
               </span>
             </div>
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              Generates per-user book suggestions using the active AI provider. {formatInterval(config.interval_minutes)}.
+              Generates per-user book suggestions using the active AI provider. Schedule is managed above.
             </p>
           </div>
           <div onClick={e => e.stopPropagation()}>
@@ -187,41 +166,24 @@ export default function AISuggestionsJobCard({ onRunKicked }: AISuggestionsJobCa
             </label>
           </div>
 
-          {/* Cadence */}
+          {/* Per-user cooldown — separate concern from the schedule cron
+              above. The scheduler fires on the cron; this value gates each
+              individual user so they don't get a new run more often than
+              this even if the cron fires more frequently. */}
           <div>
-            <label className="block text-sm font-medium text-gray-900 dark:text-white">Cadence</label>
+            <label className="block text-sm font-medium text-gray-900 dark:text-white">Per-user cooldown</label>
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-              How often the scheduler should enqueue a run for each opted-in user.
+              Minimum time between scheduled runs for the same user. Manual and admin runs bypass this.
             </p>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <select
-                value={
-                  INTERVAL_PRESETS.some(p => p.minutes === config.interval_minutes)
-                    ? String(config.interval_minutes)
-                    : '__custom__'
-                }
-                onChange={e => {
-                  if (e.target.value !== '__custom__') {
-                    set('interval_minutes', Number(e.target.value))
-                  }
-                }}
-                className="rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
-              >
-                {INTERVAL_PRESETS.map(p => (
-                  <option key={p.minutes} value={p.minutes}>{p.label}</option>
-                ))}
-                <option value="__custom__">Custom…</option>
-              </select>
-              <div className="flex items-center gap-2">
-                <input
-                  type="number"
-                  min={0}
-                  value={config.interval_minutes}
-                  onChange={e => set('interval_minutes', Math.max(0, Number(e.target.value)))}
-                  className="w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
-                />
-                <span className="text-xs text-gray-500 dark:text-gray-400">minutes</span>
-              </div>
+            <div className="mt-2 flex items-center gap-2">
+              <input
+                type="number"
+                min={0}
+                value={config.interval_minutes}
+                onChange={e => set('interval_minutes', Math.max(0, Number(e.target.value)))}
+                className="w-28 rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+              <span className="text-xs text-gray-500 dark:text-gray-400">minutes</span>
             </div>
           </div>
 

--- a/src/pages/jobs/JobKindPage.tsx
+++ b/src/pages/jobs/JobKindPage.tsx
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { useAuth, ApiError } from '../../auth/AuthContext'
+import PageHeader from '../../components/PageHeader'
+import { useToast } from '../../components/Toast'
+import { usePageTitle } from '../../hooks/usePageTitle'
+import AISuggestionsJobCard from './AISuggestionsJobCard'
+import JobSchedulesSection from './JobSchedulesSection'
+
+interface Schedule {
+  kind: string
+  display_name: string
+  description: string
+  cron: string
+  enabled: boolean
+  last_fired_at?: string
+}
+
+interface UnifiedJobRow {
+  id: string
+  kind: string
+  status: string
+  triggered_by: string
+  error?: string
+  progress: Record<string, unknown>
+  started_at?: string | null
+  finished_at?: string | null
+  created_at: string
+}
+
+// JobKindPage is the per-kind settings surface: schedule editor +
+// (for AI suggestions) the provider-specific config + a "Run now"
+// button + recent runs filtered to this kind. Reached from the jobs
+// overview.
+export default function JobKindPage() {
+  const { kind = '' } = useParams<{ kind: string }>()
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const [schedule, setSchedule] = useState<Schedule | null>(null)
+  const [recent, setRecent] = useState<UnifiedJobRow[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [running, setRunning] = useState(false)
+  usePageTitle(schedule ? schedule.display_name : 'Job')
+
+  const load = useCallback(async () => {
+    setError(null)
+    try {
+      const [schedules, history] = await Promise.all([
+        callApi<Schedule[]>('/api/v1/admin/jobs/schedules'),
+        callApi<{ items: UnifiedJobRow[] }>(
+          `/api/v1/admin/jobs/history?kind=${encodeURIComponent(kind)}&limit=10`,
+        ),
+      ])
+      const match = (schedules ?? []).find(s => s.kind === kind)
+      setSchedule(match ?? null)
+      setRecent(history?.items ?? [])
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load job')
+    }
+  }, [callApi, kind])
+
+  useEffect(() => { load() }, [load])
+
+  // Run now posts to the kind-specific endpoint; each kind wires a
+  // different admin trigger. AI suggestions uses the scheduled fanout
+  // path; cover backfill has no admin trigger yet (cron-only).
+  const runNow = async () => {
+    setRunning(true)
+    try {
+      switch (kind) {
+        case 'ai_suggestions':
+          await callApi('/api/v1/admin/jobs/ai-suggestions/run', { method: 'POST' })
+          showToast('AI suggestions run queued', { variant: 'success' })
+          break
+        default:
+          showToast('Run Now is not available for this job', { variant: 'error' })
+      }
+      // Short delay then reload so the new row shows up in recent runs.
+      setTimeout(load, 1500)
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to run', { variant: 'error' })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  const runNowAvailable = useMemo(() => kind === 'ai_suggestions', [kind])
+
+  if (error) {
+    return (
+      <>
+        <PageHeader title="Job" breadcrumbs={[{ label: 'Settings', to: '/admin/settings' }, { label: 'Jobs', to: '/admin/settings/jobs' }]} />
+        <div className="p-8 max-w-3xl mx-auto">
+          <div className="rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  const title = schedule?.display_name || kind || 'Job'
+
+  return (
+    <>
+      <PageHeader
+        title={title}
+        description={schedule?.description}
+        breadcrumbs={[
+          { label: 'Settings', to: '/admin/settings' },
+          { label: 'Jobs', to: '/admin/settings/jobs' },
+          { label: title },
+        ]}
+        actions={runNowAvailable ? (
+          <button
+            type="button"
+            onClick={runNow}
+            disabled={running}
+            className="rounded-lg border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-2 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+          >
+            {running ? 'Running…' : 'Run now'}
+          </button>
+        ) : undefined}
+      />
+      <div className="p-8 max-w-3xl mx-auto space-y-6">
+        {/* Schedule editor. Uses the existing section but filtered to
+            this one kind. */}
+        {schedule ? (
+          <section>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Schedule
+            </h2>
+            <JobSchedulesSection kind={kind} />
+          </section>
+        ) : (
+          <div className="rounded-md border border-dashed border-gray-300 dark:border-gray-700 px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            No schedule registered for this kind.
+          </div>
+        )}
+
+        {/* AI suggestions carries extra config beyond the cron — model
+            caps, token budgets, per-user cooldown. Rendered inline. */}
+        {kind === 'ai_suggestions' && (
+          <section>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Configuration
+            </h2>
+            <AISuggestionsJobCard onRunKicked={() => setTimeout(load, 1500)} />
+          </section>
+        )}
+
+        {/* Recent runs for this kind — drops users into the history
+            page for a full list. */}
+        <section>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Recent runs
+            </h2>
+            <Link
+              to={`/admin/settings/jobs/history?kind=${encodeURIComponent(kind)}`}
+              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              View all →
+            </Link>
+          </div>
+          <RecentRuns rows={recent} />
+        </section>
+      </div>
+    </>
+  )
+}
+
+function RecentRuns({ rows }: { rows: UnifiedJobRow[] | null }) {
+  if (rows === null) {
+    return <div className="text-sm text-gray-400 dark:text-gray-500">Loading…</div>
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-gray-300 dark:border-gray-700 px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        No runs yet.
+      </div>
+    )
+  }
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-800">
+      {rows.map(r => (
+        <div key={r.id} className="flex items-center gap-3 px-4 py-2.5 text-sm">
+          <StatusDot status={r.status} />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-gray-800 dark:text-gray-200 font-medium capitalize">
+                {r.status}
+              </span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                · {new Date(r.created_at).toLocaleString()}
+              </span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                · {r.triggered_by}
+              </span>
+            </div>
+            {r.error && (
+              <p className="mt-0.5 text-xs text-red-600 dark:text-red-400">{r.error}</p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function StatusDot({ status }: { status: string }) {
+  const cls = status === 'completed' ? 'bg-green-500'
+    : status === 'running'   ? 'bg-blue-500 animate-pulse'
+    : status === 'failed'    ? 'bg-red-500'
+    : status === 'cancelled' ? 'bg-gray-400'
+    :                          'bg-amber-400'
+  return <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${cls}`} />
+}

--- a/src/pages/jobs/JobKindPage.tsx
+++ b/src/pages/jobs/JobKindPage.tsx
@@ -64,21 +64,16 @@ export default function JobKindPage() {
 
   useEffect(() => { load() }, [load])
 
-  // Run now posts to the kind-specific endpoint; each kind wires a
-  // different admin trigger. AI suggestions uses the scheduled fanout
-  // path; cover backfill has no admin trigger yet (cron-only).
+  // Run now uses the generic /admin/jobs/schedules/:kind/run endpoint,
+  // which fires the kind's Enqueue hook directly with triggered_by=admin.
+  // Works for every kind that has an Enqueue registered.
   const runNow = async () => {
     setRunning(true)
     try {
-      switch (kind) {
-        case 'ai_suggestions':
-          await callApi('/api/v1/admin/jobs/ai-suggestions/run', { method: 'POST' })
-          showToast('AI suggestions run queued', { variant: 'success' })
-          break
-        default:
-          showToast('Run Now is not available for this job', { variant: 'error' })
-      }
-      // Short delay then reload so the new row shows up in recent runs.
+      await callApi(`/api/v1/admin/jobs/schedules/${encodeURIComponent(kind)}/run`, {
+        method: 'POST',
+      })
+      showToast(`${schedule?.display_name || kind} run queued`, { variant: 'success' })
       setTimeout(load, 1500)
     } catch (err) {
       showToast(err instanceof ApiError ? err.message : 'Failed to run', { variant: 'error' })
@@ -87,13 +82,13 @@ export default function JobKindPage() {
     }
   }
 
-  const runNowAvailable = useMemo(() => kind === 'ai_suggestions', [kind])
+  const runNowAvailable = useMemo(() => schedule !== null, [schedule])
 
   if (error) {
     return (
       <>
         <PageHeader title="Job" breadcrumbs={[{ label: 'Settings', to: '/admin/settings' }, { label: 'Jobs', to: '/admin/settings/jobs' }]} />
-        <div className="p-8 max-w-3xl mx-auto">
+        <div className="max-w-3xl px-8 py-8">
           <div className="rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
             {error}
           </div>
@@ -125,7 +120,7 @@ export default function JobKindPage() {
           </button>
         ) : undefined}
       />
-      <div className="p-8 max-w-3xl mx-auto space-y-6">
+      <div className="max-w-3xl px-8 py-8 space-y-6">
         {/* Schedule editor. Uses the existing section but filtered to
             this one kind. */}
         {schedule ? (

--- a/src/pages/jobs/JobSchedulesSection.tsx
+++ b/src/pages/jobs/JobSchedulesSection.tsx
@@ -24,7 +24,13 @@ interface Schedule {
   last_fired_at?: string
 }
 
-export default function JobSchedulesSection() {
+interface JobSchedulesSectionProps {
+  // kind filters to a single kind's schedule row. Used by the per-kind
+  // settings page; omitted by the (future) multi-kind admin index.
+  kind?: string
+}
+
+export default function JobSchedulesSection({ kind }: JobSchedulesSectionProps = {}) {
   const { callApi } = useAuth()
   const { show: showToast } = useToast()
   const [schedules, setSchedules] = useState<Schedule[] | null>(null)
@@ -34,11 +40,12 @@ export default function JobSchedulesSection() {
     setError(null)
     try {
       const list = await callApi<Schedule[]>('/api/v1/admin/jobs/schedules')
-      setSchedules(list ?? [])
+      const filtered = kind ? (list ?? []).filter(s => s.kind === kind) : (list ?? [])
+      setSchedules(filtered)
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load schedules')
     }
-  }, [callApi])
+  }, [callApi, kind])
 
   useEffect(() => { load() }, [load])
 

--- a/src/pages/jobs/JobSchedulesSection.tsx
+++ b/src/pages/jobs/JobSchedulesSection.tsx
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useCallback, useEffect, useState } from 'react'
+import { Cron } from 'react-js-cron'
+import type { CronError } from 'react-js-cron'
+import 'react-js-cron/dist/styles.css'
+import { useAuth, ApiError } from '../../auth/AuthContext'
+import { useToast } from '../../components/Toast'
+
+// Mirrors ScheduleView on the api side — one row per registered schedulable
+// job kind. Config is intentionally kept opaque here; kind-specific config
+// lives in the corresponding job card (e.g. AISuggestionsJobCard edits the
+// AI suggestions config directly via /admin/jobs/ai-suggestions). This
+// section only owns the cron expression + enabled flag.
+interface Schedule {
+  id: string
+  kind: string
+  display_name: string
+  description: string
+  cron: string
+  enabled: boolean
+  config: Record<string, unknown>
+  last_fired_at?: string
+}
+
+export default function JobSchedulesSection() {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const [schedules, setSchedules] = useState<Schedule[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setError(null)
+    try {
+      const list = await callApi<Schedule[]>('/api/v1/admin/jobs/schedules')
+      setSchedules(list ?? [])
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load schedules')
+    }
+  }, [callApi])
+
+  useEffect(() => { load() }, [load])
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+        {error}
+      </div>
+    )
+  }
+  if (schedules === null) {
+    return <div className="text-sm text-gray-400 dark:text-gray-500">Loading schedules…</div>
+  }
+  if (schedules.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-gray-300 dark:border-gray-700 px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        No scheduled jobs registered.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {schedules.map(s => (
+        <ScheduleRow
+          key={s.kind}
+          initial={s}
+          onSaved={load}
+          onError={setError}
+          showToast={showToast}
+        />
+      ))}
+    </div>
+  )
+}
+
+function ScheduleRow({ initial, onSaved, onError, showToast }: {
+  initial: Schedule
+  onSaved: () => void
+  onError: (msg: string) => void
+  showToast: (msg: string, opts?: { variant?: 'success' | 'error' }) => void
+}) {
+  const { callApi } = useAuth()
+  const [cron, setCron] = useState(initial.cron)
+  const [enabled, setEnabled] = useState(initial.enabled)
+  const [cronErr, setCronErr] = useState<CronError>()
+  const [saving, setSaving] = useState(false)
+
+  // Detect dirty state so the Save button only lights up when there's
+  // something to persist — prevents accidental churn of updated_at.
+  const dirty = cron !== initial.cron || enabled !== initial.enabled
+
+  const save = async () => {
+    if (cronErr) {
+      onError(cronErr.description || 'Invalid cron expression')
+      return
+    }
+    setSaving(true)
+    try {
+      await callApi(`/api/v1/admin/jobs/schedules/${encodeURIComponent(initial.kind)}`, {
+        method: 'PUT',
+        body: JSON.stringify({ cron, enabled, config: initial.config }),
+      })
+      showToast(`${initial.display_name} schedule saved`, { variant: 'success' })
+      onSaved()
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to save schedule', { variant: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
+      <div className="flex items-center justify-between gap-3 px-4 py-3 bg-gray-50 dark:bg-gray-800">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{initial.display_name}</h3>
+            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+              enabled
+                ? 'bg-green-50 dark:bg-green-950/50 text-green-700 dark:text-green-400 ring-1 ring-green-200 dark:ring-green-800'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
+            }`}>
+              {enabled ? 'Enabled' : 'Disabled'}
+            </span>
+            {initial.last_fired_at && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                Last fired: {new Date(initial.last_fired_at).toLocaleString()}
+              </span>
+            )}
+          </div>
+          {initial.description && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{initial.description}</p>
+          )}
+        </div>
+        <label className="relative inline-flex items-center cursor-pointer flex-shrink-0">
+          <input
+            type="checkbox"
+            className="sr-only peer"
+            checked={enabled}
+            onChange={e => setEnabled(e.target.checked)}
+          />
+          <div className="w-10 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full" />
+        </label>
+      </div>
+
+      <div className="p-4 space-y-3">
+        <div>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Schedule (cron)
+          </label>
+          <div className="cron-editor">
+            <Cron
+              value={cron}
+              setValue={(v: string) => setCron(v)}
+              onError={setCronErr}
+              clearButton={false}
+            />
+          </div>
+          <p className="mt-2 font-mono text-xs text-gray-600 dark:text-gray-400">{cron}</p>
+          {cronErr && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">{cronErr.description}</p>
+          )}
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => { setCron(initial.cron); setEnabled(initial.enabled); setCronErr(undefined) }}
+            disabled={!dirty || saving}
+            className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={!dirty || saving || !!cronErr}
+            className="rounded-md border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/jobs/JobsHistoryPage.tsx
+++ b/src/pages/jobs/JobsHistoryPage.tsx
@@ -609,7 +609,7 @@ export default function JobsHistoryPage() {
           </button>
         ) : undefined}
       />
-      <div className="p-8 max-w-4xl mx-auto">
+      <div className="max-w-4xl px-8 py-8">
 
       {error && (
         <div className="mb-6 rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">

--- a/src/pages/jobs/JobsHistoryPage.tsx
+++ b/src/pages/jobs/JobsHistoryPage.tsx
@@ -295,10 +295,10 @@ function JobRow({
     : null
 
   return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+    <div className="bg-white dark:bg-gray-900">
       <button
         onClick={toggleExpand}
-        className="w-full text-left px-5 py-4 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+        className="w-full text-left px-5 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
       >
         <div className="flex items-center gap-4">
           <svg
@@ -625,7 +625,7 @@ export default function JobsHistoryPage() {
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800 overflow-hidden">
           {jobs.map(job => (
             <JobRow
               key={job.id}

--- a/src/pages/jobs/JobsHistoryPage.tsx
+++ b/src/pages/jobs/JobsHistoryPage.tsx
@@ -10,7 +10,7 @@ import { usePageTitle } from '../../hooks/usePageTitle'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type JobType = 'import' | 'metadata' | 'cover' | 'ai_suggestions'
+type JobType = 'import' | 'metadata' | 'cover' | 'cover_backfill' | 'ai_suggestions'
 type JobStatus = 'pending' | 'processing' | 'done' | 'failed' | 'cancelled'
 
 interface ImportItem {
@@ -99,6 +99,7 @@ function unifiedToJob(u: UnifiedJobRow): Job {
     case 'import':         jobType = 'import'; break
     case 'enrichment':     jobType = 'metadata'; break
     case 'ai_suggestions': jobType = 'ai_suggestions'; break
+    case 'cover_backfill': jobType = 'cover_backfill'; break
     default:               jobType = 'metadata'; break
   }
 
@@ -130,10 +131,11 @@ function unifiedToJob(u: UnifiedJobRow): Job {
 
 function TypeBadge({ type }: { type: JobType }) {
   const cfg: Record<JobType, { label: string; cls: string }> = {
-    import:         { label: 'Import',      cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
-    metadata:       { label: 'Metadata',    cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
-    cover:          { label: 'Covers',      cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
-    ai_suggestions: { label: 'Suggestions', cls: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' },
+    import:         { label: 'Import',         cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
+    metadata:       { label: 'Metadata',       cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
+    cover:          { label: 'Covers',         cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
+    cover_backfill: { label: 'Cover backfill', cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
+    ai_suggestions: { label: 'Suggestions',    cls: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' },
   }
   const { label, cls } = cfg[type] ?? cfg.import
   return (
@@ -211,10 +213,12 @@ function JobRow({
   const [deleting, setDeleting] = useState(false)
 
   const isAISuggestions = job.type === 'ai_suggestions'
-  // AI suggestion runs support cancel (admin only) but not delete; enrichment
-  // and import jobs support both.
-  const canCancel   = job.status === 'pending' || job.status === 'processing'
-  const canDelete   = !isAISuggestions && (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled')
+  const isCoverBackfill = job.type === 'cover_backfill'
+  // Cover-backfill parents and AI suggestion rows delete via the unified
+  // /admin/jobs/:id route (cascades through the kind-specific legacy
+  // tables); enrichment and import jobs still hit their per-kind endpoints.
+  const canCancel   = !isCoverBackfill && (job.status === 'pending' || job.status === 'processing')
+  const canDelete   = job.status === 'done' || job.status === 'failed' || job.status === 'cancelled'
   const isActive    = job.status === 'pending' || job.status === 'processing'
   const isEnrichment = job.type === 'metadata' || job.type === 'cover'
 
@@ -233,9 +237,10 @@ function JobRow({
 
   const toggleExpand = async () => {
     const isEnr = job.type === 'metadata' || job.type === 'cover'
-    // AI suggestion runs expand into a RunDetailPanel, which self-fetches —
-    // skip the items lookup for that type.
-    if (!expanded && !isAISuggestions) {
+    // AI suggestion runs expand into a RunDetailPanel, which self-fetches.
+    // Cover-backfill parents are orchestrators with no items — the expand
+    // panel just shows the summary, no fetch required.
+    if (!expanded && !isAISuggestions && !isCoverBackfill) {
       setLoadingItems(true)
       try {
         if (isEnr) {
@@ -280,9 +285,11 @@ function JobRow({
     if (!canDelete || deleting) return
     setDeleting(true)
     try {
-      const path = isEnrichment
-        ? `/api/v1/enrichment-batches/${job.id}`
-        : `/api/v1/imports/${job.id}`
+      const path = isCoverBackfill || isAISuggestions
+        ? `/api/v1/admin/jobs/${job.id}`
+        : isEnrichment
+          ? `/api/v1/enrichment-batches/${job.id}`
+          : `/api/v1/imports/${job.id}`
       await callApi(path, { method: 'DELETE' })
       onDeleted(job.id)
     } catch {
@@ -420,6 +427,18 @@ function JobRow({
                 hideSummary
               />
             </div>
+          ) : isCoverBackfill ? (
+            <div className="px-5 py-4 text-sm text-gray-600 dark:text-gray-400 space-y-1">
+              <p>
+                Enumerated {job.total_rows} book{job.total_rows === 1 ? '' : 's'} missing covers and dispatched cover-only enrichment batches.
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-500">
+                Per-book progress lives on the child Metadata rows above/below.
+              </p>
+              {job.run_error && (
+                <p className="text-xs text-red-600 dark:text-red-400">{job.run_error}</p>
+              )}
+            </div>
           ) : loadingItems ? (
             <div className="flex items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
               <div className="w-4 h-4 rounded-full border-2 border-blue-500 border-t-transparent animate-spin mr-2" />
@@ -447,7 +466,9 @@ function JobRow({
                     </div>
                     {item.book_id && (
                       <Link
-                        to={`/libraries/${job.library_id}/books/${item.book_id}`}
+                        to={job.library_id
+                          ? `/libraries/${job.library_id}/books/${item.book_id}`
+                          : `/books/${item.book_id}`}
                         className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex-shrink-0"
                         onClick={e => e.stopPropagation()}
                       >
@@ -566,12 +587,8 @@ export default function JobsHistoryPage() {
     if (clearingAll) return
     setClearingAll(true)
     try {
-      await Promise.all([
-        callApi('/api/v1/imports', { method: 'DELETE' }),
-        callApi('/api/v1/enrichment-batches', { method: 'DELETE' }),
-        callApi('/api/v1/admin/jobs/ai-suggestions/runs', { method: 'DELETE' }).catch(() => {}),
-      ])
-      setJobs(prev => prev.filter(j => j.status === 'pending' || j.status === 'processing'))
+      await callApi('/api/v1/admin/jobs/history', { method: 'DELETE' })
+      setJobs(prev => prev.filter(j => j.status === 'pending' || j.status === 'processing' || j.status === 'running'))
     } catch {
       // non-fatal
     } finally {
@@ -579,7 +596,7 @@ export default function JobsHistoryPage() {
     }
   }
 
-  const hasFinished = jobs.some(j => j.status === 'done' || j.status === 'failed' || j.status === 'cancelled')
+  const hasFinished = jobs.some(j => j.status === 'done' || j.status === 'completed' || j.status === 'failed' || j.status === 'cancelled')
 
   if (loading) {
     return (

--- a/src/pages/jobs/JobsHistoryPage.tsx
+++ b/src/pages/jobs/JobsHistoryPage.tsx
@@ -1,0 +1,642 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth, ApiError } from '../../auth/AuthContext'
+import PageHeader from '../../components/PageHeader'
+import RunDetailPanel from '../../components/RunDetailPanel'
+import { usePageTitle } from '../../hooks/usePageTitle'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type JobType = 'import' | 'metadata' | 'cover' | 'ai_suggestions'
+type JobStatus = 'pending' | 'processing' | 'done' | 'failed' | 'cancelled'
+
+interface ImportItem {
+  id: string
+  row_number: number
+  status: 'pending' | 'done' | 'skipped' | 'failed'
+  title: string
+  isbn: string
+  message: string
+  book_id?: string
+}
+
+interface EnrichmentItem {
+  id: string
+  book_id?: string
+  book_title: string
+  status: 'pending' | 'done' | 'failed' | 'skipped'
+  message?: string
+}
+
+interface Job {
+  id: string
+  type: JobType
+  library_id: string
+  library_name?: string
+  status: JobStatus
+  // import jobs use rows; enrichment batches use books — normalised below
+  total_rows: number
+  processed_rows: number
+  failed_rows: number
+  skipped_rows: number
+  created_at: string
+  updated_at: string
+  items?: ImportItem[]
+  // AI-suggestion-run-only fields (undefined for imports/enrichment)
+  triggered_by?: string
+  provider_type?: string
+  model_id?: string
+  tokens_in?: number
+  tokens_out?: number
+  estimated_cost_usd?: number
+  user_id?: string
+  run_error?: string
+  finished_at?: string
+}
+
+// UnifiedJobRow mirrors the JobView the unified /admin/jobs/history
+// endpoint returns. Progress is a kind-specific JSON blob the umbrella
+// row holds for summary UI — counters extracted via unifiedToJob below.
+interface UnifiedJobRow {
+  id: string
+  kind: string
+  status: string
+  triggered_by: string
+  created_by?: string | null
+  schedule_id?: string | null
+  error?: string
+  progress: Record<string, unknown>
+  started_at?: string | null
+  finished_at?: string | null
+  created_at: string
+  updated_at: string
+}
+
+// unifiedToJob folds the umbrella row + kind-specific progress into the
+// page-local Job shape so the existing per-kind rendering still works.
+function unifiedToJob(u: UnifiedJobRow): Job {
+  const mappedStatus: JobStatus =
+    u.status === 'pending' ? 'pending'
+      : u.status === 'running' ? 'processing'
+      : u.status === 'completed' ? 'done'
+      : u.status === 'failed' ? 'failed'
+      : u.status === 'cancelled' ? 'cancelled'
+      : 'pending'
+
+  // Kind-specific counters live in progress as { processed, failed, skipped, total }
+  // for import and enrichment; AI suggestions writes { tokens_in, tokens_out, cost_usd }.
+  const p = u.progress ?? {}
+  const num = (k: string): number => {
+    const v = p[k]
+    return typeof v === 'number' ? v : 0
+  }
+
+  let jobType: JobType
+  switch (u.kind) {
+    case 'import':         jobType = 'import'; break
+    case 'enrichment':     jobType = 'metadata'; break
+    case 'ai_suggestions': jobType = 'ai_suggestions'; break
+    default:               jobType = 'metadata'; break
+  }
+
+  return {
+    id: u.id,
+    type: jobType,
+    library_id: '', // umbrella rows don't carry library_id; the per-kind
+                   // detail fetch still does when the UI needs it
+    status: mappedStatus,
+    total_rows: num('total'),
+    processed_rows: num('processed'),
+    failed_rows: num('failed'),
+    skipped_rows: num('skipped'),
+    created_at: u.created_at,
+    updated_at: u.updated_at,
+    triggered_by: u.triggered_by,
+    tokens_in: num('tokens_in'),
+    tokens_out: num('tokens_out'),
+    estimated_cost_usd: typeof p.cost_usd === 'number' ? (p.cost_usd as number) : 0,
+    run_error: u.error || undefined,
+    finished_at: u.finished_at || undefined,
+  }
+}
+
+// Legacy batchToJob / runToJob helpers removed with the unified history
+// endpoint — unifiedToJob above handles every kind now.
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function TypeBadge({ type }: { type: JobType }) {
+  const cfg: Record<JobType, { label: string; cls: string }> = {
+    import:         { label: 'Import',      cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
+    metadata:       { label: 'Metadata',    cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
+    cover:          { label: 'Covers',      cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
+    ai_suggestions: { label: 'Suggestions', cls: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' },
+  }
+  const { label, cls } = cfg[type] ?? cfg.import
+  return (
+    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>
+      {label}
+    </span>
+  )
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n)
+  return `${(n / 1000).toFixed(1)}k`
+}
+
+function formatDurationSec(startIso: string, endIso?: string): string | null {
+  if (!endIso) return null
+  const ms = new Date(endIso).getTime() - new Date(startIso).getTime()
+  if (!Number.isFinite(ms) || ms < 0) return null
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const m = Math.floor(ms / 60_000)
+  const s = Math.round((ms % 60_000) / 1000)
+  return `${m}m${s.toString().padStart(2, '0')}s`
+}
+
+function StatusBadge({ status }: { status: JobStatus }) {
+  const cfg: Record<JobStatus, { label: string; cls: string; spin?: boolean }> = {
+    pending:    { label: 'Queued',     cls: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300' },
+    processing: { label: 'Processing', cls: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300', spin: true },
+    done:       { label: 'Done',       cls: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300' },
+    failed:     { label: 'Failed',     cls: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300' },
+    cancelled:  { label: 'Cancelled',  cls: 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400' },
+  }
+  const { label, cls, spin } = cfg[status] ?? cfg.failed
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}>
+      {spin && <span className="w-2 h-2 rounded-full border border-blue-500 border-t-transparent animate-spin" />}
+      {label}
+    </span>
+  )
+}
+
+function ItemStatusDot({ status }: { status: ImportItem['status'] }) {
+  const cls: Record<ImportItem['status'], string> = {
+    pending: 'bg-gray-300 dark:bg-gray-600',
+    done:    'bg-green-500',
+    skipped: 'bg-amber-400',
+    failed:  'bg-red-500',
+  }
+  return <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${cls[status]}`} />
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  })
+}
+
+// ─── Job row ──────────────────────────────────────────────────────────────────
+
+function JobRow({
+  job,
+  onCancelled,
+  onDeleted,
+}: {
+  job: Job
+  onCancelled: (id: string) => void
+  onDeleted: (id: string) => void
+}) {
+  const { callApi } = useAuth()
+  const [expanded, setExpanded] = useState(false)
+  const [items, setItems] = useState<ImportItem[] | null>(job.items ?? null)
+  const [enrichItems, setEnrichItems] = useState<EnrichmentItem[] | null>(null)
+  const [loadingItems, setLoadingItems] = useState(false)
+  const [cancelling, setCancelling] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const isAISuggestions = job.type === 'ai_suggestions'
+  // AI suggestion runs support cancel (admin only) but not delete; enrichment
+  // and import jobs support both.
+  const canCancel   = job.status === 'pending' || job.status === 'processing'
+  const canDelete   = !isAISuggestions && (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled')
+  const isActive    = job.status === 'pending' || job.status === 'processing'
+  const isEnrichment = job.type === 'metadata' || job.type === 'cover'
+
+  // While an enrichment batch is expanded and still running, poll its items so
+  // the per-book status list updates in real time (same cadence as the parent poll).
+  useEffect(() => {
+    if (!expanded || !isEnrichment || !isActive) return
+    const refresh = () => {
+      callApi<{ items: EnrichmentItem[] }>(`/api/v1/enrichment-batches/${job.id}`)
+        .then(full => setEnrichItems(full.items ?? []))
+        .catch(() => {})
+    }
+    const id = setInterval(refresh, 3000)
+    return () => clearInterval(id)
+  }, [expanded, isEnrichment, isActive, job.id, callApi])
+
+  const toggleExpand = async () => {
+    const isEnr = job.type === 'metadata' || job.type === 'cover'
+    // AI suggestion runs expand into a RunDetailPanel, which self-fetches —
+    // skip the items lookup for that type.
+    if (!expanded && !isAISuggestions) {
+      setLoadingItems(true)
+      try {
+        if (isEnr) {
+          const full = await callApi<{ items: EnrichmentItem[] }>(`/api/v1/enrichment-batches/${job.id}`)
+          setEnrichItems(full.items ?? [])
+        } else if (items === null) {
+          const full = await callApi<Job>(`/api/v1/libraries/${job.library_id}/imports/${job.id}`)
+          setItems(full.items ?? [])
+        }
+      } catch {
+        if (isEnr) setEnrichItems([])
+        else setItems([])
+      } finally {
+        setLoadingItems(false)
+      }
+    }
+    setExpanded(e => !e)
+  }
+
+  const handleCancel = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!canCancel || cancelling) return
+    setCancelling(true)
+    try {
+      if (isAISuggestions) {
+        await callApi(`/api/v1/admin/jobs/ai-suggestions/runs/${job.id}`, { method: 'DELETE' })
+      } else if (isEnrichment) {
+        await callApi(`/api/v1/enrichment-batches/${job.id}/cancel`, { method: 'POST' })
+      } else {
+        await callApi(`/api/v1/imports/${job.id}/cancel`, { method: 'POST' })
+      }
+      onCancelled(job.id)
+    } catch {
+      // non-fatal — parent will refresh
+    } finally {
+      setCancelling(false)
+    }
+  }
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!canDelete || deleting) return
+    setDeleting(true)
+    try {
+      const path = isEnrichment
+        ? `/api/v1/enrichment-batches/${job.id}`
+        : `/api/v1/imports/${job.id}`
+      await callApi(path, { method: 'DELETE' })
+      onDeleted(job.id)
+    } catch {
+      setDeleting(false)
+    }
+  }
+
+  const successRows = job.status === 'done'
+    ? Math.max(0, job.processed_rows - job.failed_rows - job.skipped_rows)
+    : null
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+      <button
+        onClick={toggleExpand}
+        className="w-full text-left px-5 py-4 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+      >
+        <div className="flex items-center gap-4">
+          <svg
+            className={`w-4 h-4 text-gray-400 flex-shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+
+          <div className="flex-1 min-w-0 grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-3">
+            <TypeBadge type={job.type} />
+            <StatusBadge status={job.status} />
+
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 mb-0.5">
+                <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                  {isAISuggestions
+                    ? `Triggered by ${job.triggered_by ?? 'scheduler'}${job.user_id ? ` · user ${job.user_id.slice(0, 8)}` : ''}`
+                    : (job.library_name ?? job.library_id)}
+                </span>
+                <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
+                  {job.id.slice(0, 8)}
+                </span>
+              </div>
+              {isAISuggestions ? (
+                isActive ? (
+                  <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                    <span className="inline-block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                    <span>Running…</span>
+                    {job.provider_type && (
+                      <span className="text-gray-400">{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {job.provider_type && (
+                      <span>{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
+                    )}
+                    {(job.tokens_in !== undefined || job.tokens_out !== undefined) && (
+                      <span className="tabular-nums">
+                        {formatTokens(job.tokens_in ?? 0)} in / {formatTokens(job.tokens_out ?? 0)} out
+                      </span>
+                    )}
+                    {job.estimated_cost_usd !== undefined && job.estimated_cost_usd > 0 && (
+                      <span className="tabular-nums">${job.estimated_cost_usd.toFixed(4)}</span>
+                    )}
+                    {formatDurationSec(job.created_at, job.finished_at) && (
+                      <span className="tabular-nums">{formatDurationSec(job.created_at, job.finished_at)}</span>
+                    )}
+                    {job.run_error && (
+                      <span className="text-red-600 dark:text-red-400 truncate max-w-xs" title={job.run_error}>
+                        {job.run_error}
+                      </span>
+                    )}
+                  </div>
+                )
+              ) : isActive ? (
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden max-w-xs">
+                    <div
+                      className="h-full rounded-full bg-blue-500 transition-all duration-500"
+                      style={{ width: job.total_rows > 0 ? `${Math.round((job.processed_rows / job.total_rows) * 100)}%` : '0%' }}
+                    />
+                  </div>
+                  <span className="text-xs text-gray-400 tabular-nums">
+                    {job.processed_rows}/{job.total_rows}
+                  </span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                  <span>{job.total_rows} {isEnrichment ? 'books' : 'rows'}</span>
+                  {successRows !== null && successRows > 0 && (
+                    <span className="text-green-600 dark:text-green-400">
+                      {successRows} {isEnrichment ? 'updated' : 'added'}
+                    </span>
+                  )}
+                  {job.skipped_rows > 0 && <span className="text-amber-600 dark:text-amber-400">{job.skipped_rows} skipped</span>}
+                  {job.failed_rows > 0 && <span className="text-red-600 dark:text-red-400">{job.failed_rows} failed</span>}
+                </div>
+              )}
+            </div>
+
+            <span className="text-xs text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
+              {formatDate(job.created_at)}
+            </span>
+
+            <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+              {canCancel && (
+                <button
+                  onClick={handleCancel}
+                  disabled={cancelling}
+                  className="text-xs text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50 transition-colors px-1 py-0.5 rounded"
+                  title="Cancel job"
+                >
+                  {cancelling ? '…' : 'Cancel'}
+                </button>
+              )}
+              {canDelete && (
+                <button
+                  onClick={handleDelete}
+                  disabled={deleting}
+                  className="text-xs text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-50 transition-colors px-1 py-0.5 rounded"
+                  title="Delete job"
+                >
+                  {deleting ? '…' : 'Delete'}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+          {isAISuggestions ? (
+            <div className="px-5 py-4">
+              <RunDetailPanel
+                endpoint={`/api/v1/admin/jobs/ai-suggestions/runs/${job.id}`}
+                hideSummary
+              />
+            </div>
+          ) : loadingItems ? (
+            <div className="flex items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
+              <div className="w-4 h-4 rounded-full border-2 border-blue-500 border-t-transparent animate-spin mr-2" />
+              Loading…
+            </div>
+          ) : isEnrichment ? (
+            enrichItems && enrichItems.length > 0 ? (
+              <div className="divide-y divide-gray-100 dark:divide-gray-800">
+                {enrichItems.map(item => (
+                  <div key={item.id} className="flex items-start gap-3 px-5 py-2.5 text-sm">
+                    <ItemStatusDot status={item.status} />
+                    <div className="flex-1 min-w-0">
+                      <span className="text-gray-800 dark:text-gray-200 font-medium">
+                        {item.book_title || <span className="text-gray-400 italic font-mono text-xs">{item.book_id?.slice(0, 8) ?? 'Unknown'}</span>}
+                      </span>
+                      {item.message && (
+                        <p className={`text-xs mt-0.5 ${
+                          item.status === 'failed' ? 'text-red-600 dark:text-red-400'
+                            : item.status === 'skipped' ? 'text-amber-600 dark:text-amber-400'
+                            : 'text-gray-400 dark:text-gray-500'
+                        }`}>
+                          {item.message}
+                        </p>
+                      )}
+                    </div>
+                    {item.book_id && (
+                      <Link
+                        to={`/libraries/${job.library_id}/books/${item.book_id}`}
+                        className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex-shrink-0"
+                        onClick={e => e.stopPropagation()}
+                      >
+                        View
+                      </Link>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="px-5 py-4 text-sm text-gray-400 dark:text-gray-500">No items.</p>
+            )
+          ) : items && items.length > 0 ? (
+            <div className="divide-y divide-gray-100 dark:divide-gray-800">
+              {items.map(item => (
+                <div key={item.id} className="flex items-start gap-3 px-5 py-2.5 text-sm">
+                  <span className="text-xs tabular-nums text-gray-400 dark:text-gray-500 w-8 flex-shrink-0 pt-0.5 text-right">
+                    {item.row_number}
+                  </span>
+                  <ItemStatusDot status={item.status} />
+                  <div className="flex-1 min-w-0">
+                    <span className="text-gray-800 dark:text-gray-200 font-medium">
+                      {item.title || <span className="text-gray-400 italic">Untitled</span>}
+                    </span>
+                    {item.isbn && <span className="ml-2 text-xs text-gray-400 font-mono">{item.isbn}</span>}
+                    {item.message && (
+                      <p className={`text-xs mt-0.5 ${
+                        item.status === 'failed' ? 'text-red-600 dark:text-red-400'
+                          : item.status === 'skipped' ? 'text-amber-600 dark:text-amber-400'
+                          : 'text-gray-400 dark:text-gray-500'
+                      }`}>
+                        {item.message}
+                      </p>
+                    )}
+                  </div>
+                  {item.book_id && (
+                    <Link
+                      to={`/libraries/${job.library_id}/books/${item.book_id}`}
+                      className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex-shrink-0"
+                      onClick={e => e.stopPropagation()}
+                    >
+                      View
+                    </Link>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="px-5 py-4 text-sm text-gray-400 dark:text-gray-500">No items.</p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── JobsPage ─────────────────────────────────────────────────────────────────
+
+export default function JobsHistoryPage() {
+  const { callApi } = useAuth()
+  const [jobs, setJobs] = useState<Job[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [clearingAll, setClearingAll] = useState(false)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const burstTimers = useRef<Array<ReturnType<typeof setTimeout>>>([])
+  usePageTitle('Job history')
+
+  const loadJobs = async () => {
+    try {
+      // One fetch replaces the three-endpoint fanout — the unified
+      // /admin/jobs/history returns every kind in one paginated shape.
+      const resp = await callApi<{ items: UnifiedJobRow[]; total: number }>(
+        '/api/v1/admin/jobs/history?limit=200'
+      )
+      const merged = (resp?.items ?? []).map(unifiedToJob)
+      setJobs(merged)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load jobs')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadJobs()
+    return () => {
+      burstTimers.current.forEach(t => clearTimeout(t))
+      burstTimers.current = []
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Auto-poll while any job is active
+  useEffect(() => {
+    const hasActive = jobs.some(j => j.status === 'pending' || j.status === 'processing')
+    if (hasActive && !pollRef.current) {
+      pollRef.current = setInterval(loadJobs, 3000)
+    } else if (!hasActive && pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+    return () => { if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null } }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jobs])
+
+  const handleCancelled = (id: string) => {
+    setJobs(prev => prev.map(j => j.id === id ? { ...j, status: 'cancelled' as JobStatus } : j))
+  }
+
+  const handleDeleted = (id: string) => {
+    setJobs(prev => prev.filter(j => j.id !== id))
+  }
+
+  const handleClearFinished = async () => {
+    if (clearingAll) return
+    setClearingAll(true)
+    try {
+      await Promise.all([
+        callApi('/api/v1/imports', { method: 'DELETE' }),
+        callApi('/api/v1/enrichment-batches', { method: 'DELETE' }),
+        callApi('/api/v1/admin/jobs/ai-suggestions/runs', { method: 'DELETE' }).catch(() => {}),
+      ])
+      setJobs(prev => prev.filter(j => j.status === 'pending' || j.status === 'processing'))
+    } catch {
+      // non-fatal
+    } finally {
+      setClearingAll(false)
+    }
+  }
+
+  const hasFinished = jobs.some(j => j.status === 'done' || j.status === 'failed' || j.status === 'cancelled')
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20 text-gray-400 dark:text-gray-500">
+        <div className="w-5 h-5 rounded-full border-2 border-blue-500 border-t-transparent animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <PageHeader
+        title="Job history"
+        description="Every job run across every kind, newest first."
+        breadcrumbs={[
+          { label: 'Settings', to: '/admin/settings' },
+          { label: 'Jobs', to: '/admin/settings/jobs' },
+          { label: 'History' },
+        ]}
+        actions={hasFinished ? (
+          <button
+            onClick={handleClearFinished}
+            disabled={clearingAll}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:border-red-400 hover:text-red-600 dark:hover:border-red-500 dark:hover:text-red-400 disabled:opacity-50 transition-colors"
+          >
+            {clearingAll ? 'Clearing…' : 'Clear finished'}
+          </button>
+        ) : undefined}
+      />
+      <div className="p-8 max-w-4xl mx-auto">
+
+      {error && (
+        <div className="mb-6 rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {jobs.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 p-12 text-center">
+          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">No jobs yet</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+            Start an import from the Import tool to see background jobs here.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {jobs.map(job => (
+            <JobRow
+              key={job.id}
+              job={job}
+              onCancelled={handleCancelled}
+              onDeleted={handleDeleted}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+    </>
+  )
+}

--- a/src/pages/jobs/JobsHistoryPage.tsx
+++ b/src/pages/jobs/JobsHistoryPage.tsx
@@ -588,7 +588,7 @@ export default function JobsHistoryPage() {
     setClearingAll(true)
     try {
       await callApi('/api/v1/admin/jobs/history', { method: 'DELETE' })
-      setJobs(prev => prev.filter(j => j.status === 'pending' || j.status === 'processing' || j.status === 'running'))
+      setJobs(prev => prev.filter(j => j.status === 'pending' || j.status === 'processing'))
     } catch {
       // non-fatal
     } finally {
@@ -596,7 +596,7 @@ export default function JobsHistoryPage() {
     }
   }
 
-  const hasFinished = jobs.some(j => j.status === 'done' || j.status === 'completed' || j.status === 'failed' || j.status === 'cancelled')
+  const hasFinished = jobs.some(j => j.status === 'done' || j.status === 'failed' || j.status === 'cancelled')
 
   if (loading) {
     return (

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -1,671 +1,114 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 fireball1725
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import PageHeader from '../../components/PageHeader'
-import RunDetailPanel from '../../components/RunDetailPanel'
 import { usePageTitle } from '../../hooks/usePageTitle'
-import AISuggestionsJobCard from './AISuggestionsJobCard'
-import JobSchedulesSection from './JobSchedulesSection'
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-type JobType = 'import' | 'metadata' | 'cover' | 'ai_suggestions'
-type JobStatus = 'pending' | 'processing' | 'done' | 'failed' | 'cancelled'
-
-interface ImportItem {
-  id: string
-  row_number: number
-  status: 'pending' | 'done' | 'skipped' | 'failed'
-  title: string
-  isbn: string
-  message: string
-  book_id?: string
-}
-
-interface EnrichmentItem {
-  id: string
-  book_id?: string
-  book_title: string
-  status: 'pending' | 'done' | 'failed' | 'skipped'
-  message?: string
-}
-
-interface Job {
-  id: string
-  type: JobType
-  library_id: string
-  library_name?: string
-  status: JobStatus
-  // import jobs use rows; enrichment batches use books — normalised below
-  total_rows: number
-  processed_rows: number
-  failed_rows: number
-  skipped_rows: number
-  created_at: string
-  updated_at: string
-  items?: ImportItem[]
-  // AI-suggestion-run-only fields (undefined for imports/enrichment)
-  triggered_by?: string
-  provider_type?: string
-  model_id?: string
-  tokens_in?: number
-  tokens_out?: number
-  estimated_cost_usd?: number
-  user_id?: string
-  run_error?: string
-  finished_at?: string
-}
-
-// UnifiedJobRow mirrors the JobView the unified /admin/jobs/history
-// endpoint returns. Progress is a kind-specific JSON blob the umbrella
-// row holds for summary UI — counters extracted via unifiedToJob below.
-interface UnifiedJobRow {
+// Schedule is the wire-shape returned by GET /admin/jobs/schedules —
+// one row per registered schedulable kind.
+interface Schedule {
   id: string
   kind: string
-  status: string
-  triggered_by: string
-  created_by?: string | null
-  schedule_id?: string | null
-  error?: string
-  progress: Record<string, unknown>
-  started_at?: string | null
-  finished_at?: string | null
-  created_at: string
-  updated_at: string
+  display_name: string
+  description: string
+  cron: string
+  enabled: boolean
+  last_fired_at?: string
 }
 
-// unifiedToJob folds the umbrella row + kind-specific progress into the
-// page-local Job shape so the existing per-kind rendering still works.
-function unifiedToJob(u: UnifiedJobRow): Job {
-  const mappedStatus: JobStatus =
-    u.status === 'pending' ? 'pending'
-      : u.status === 'running' ? 'processing'
-      : u.status === 'completed' ? 'done'
-      : u.status === 'failed' ? 'failed'
-      : u.status === 'cancelled' ? 'cancelled'
-      : 'pending'
-
-  // Kind-specific counters live in progress as { processed, failed, skipped, total }
-  // for import and enrichment; AI suggestions writes { tokens_in, tokens_out, cost_usd }.
-  const p = u.progress ?? {}
-  const num = (k: string): number => {
-    const v = p[k]
-    return typeof v === 'number' ? v : 0
-  }
-
-  let jobType: JobType
-  switch (u.kind) {
-    case 'import':         jobType = 'import'; break
-    case 'enrichment':     jobType = 'metadata'; break
-    case 'ai_suggestions': jobType = 'ai_suggestions'; break
-    default:               jobType = 'metadata'; break
-  }
-
-  return {
-    id: u.id,
-    type: jobType,
-    library_id: '', // umbrella rows don't carry library_id; the per-kind
-                   // detail fetch still does when the UI needs it
-    status: mappedStatus,
-    total_rows: num('total'),
-    processed_rows: num('processed'),
-    failed_rows: num('failed'),
-    skipped_rows: num('skipped'),
-    created_at: u.created_at,
-    updated_at: u.updated_at,
-    triggered_by: u.triggered_by,
-    tokens_in: num('tokens_in'),
-    tokens_out: num('tokens_out'),
-    estimated_cost_usd: typeof p.cost_usd === 'number' ? (p.cost_usd as number) : 0,
-    run_error: u.error || undefined,
-    finished_at: u.finished_at || undefined,
-  }
-}
-
-// Legacy batchToJob / runToJob helpers removed with the unified history
-// endpoint — unifiedToJob above handles every kind now.
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function TypeBadge({ type }: { type: JobType }) {
-  const cfg: Record<JobType, { label: string; cls: string }> = {
-    import:         { label: 'Import',      cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
-    metadata:       { label: 'Metadata',    cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
-    cover:          { label: 'Covers',      cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
-    ai_suggestions: { label: 'Suggestions', cls: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' },
-  }
-  const { label, cls } = cfg[type] ?? cfg.import
-  return (
-    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>
-      {label}
-    </span>
-  )
-}
-
-function formatTokens(n: number): string {
-  if (n < 1000) return String(n)
-  return `${(n / 1000).toFixed(1)}k`
-}
-
-function formatDurationSec(startIso: string, endIso?: string): string | null {
-  if (!endIso) return null
-  const ms = new Date(endIso).getTime() - new Date(startIso).getTime()
-  if (!Number.isFinite(ms) || ms < 0) return null
-  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
-  const m = Math.floor(ms / 60_000)
-  const s = Math.round((ms % 60_000) / 1000)
-  return `${m}m${s.toString().padStart(2, '0')}s`
-}
-
-function StatusBadge({ status }: { status: JobStatus }) {
-  const cfg: Record<JobStatus, { label: string; cls: string; spin?: boolean }> = {
-    pending:    { label: 'Queued',     cls: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300' },
-    processing: { label: 'Processing', cls: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300', spin: true },
-    done:       { label: 'Done',       cls: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300' },
-    failed:     { label: 'Failed',     cls: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300' },
-    cancelled:  { label: 'Cancelled',  cls: 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400' },
-  }
-  const { label, cls, spin } = cfg[status] ?? cfg.failed
-  return (
-    <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}>
-      {spin && <span className="w-2 h-2 rounded-full border border-blue-500 border-t-transparent animate-spin" />}
-      {label}
-    </span>
-  )
-}
-
-function ItemStatusDot({ status }: { status: ImportItem['status'] }) {
-  const cls: Record<ImportItem['status'], string> = {
-    pending: 'bg-gray-300 dark:bg-gray-600',
-    done:    'bg-green-500',
-    skipped: 'bg-amber-400',
-    failed:  'bg-red-500',
-  }
-  return <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${cls[status]}`} />
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
-    month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
-  })
-}
-
-// ─── Job row ──────────────────────────────────────────────────────────────────
-
-function JobRow({
-  job,
-  onCancelled,
-  onDeleted,
-}: {
-  job: Job
-  onCancelled: (id: string) => void
-  onDeleted: (id: string) => void
-}) {
-  const { callApi } = useAuth()
-  const [expanded, setExpanded] = useState(false)
-  const [items, setItems] = useState<ImportItem[] | null>(job.items ?? null)
-  const [enrichItems, setEnrichItems] = useState<EnrichmentItem[] | null>(null)
-  const [loadingItems, setLoadingItems] = useState(false)
-  const [cancelling, setCancelling] = useState(false)
-  const [deleting, setDeleting] = useState(false)
-
-  const isAISuggestions = job.type === 'ai_suggestions'
-  // AI suggestion runs support cancel (admin only) but not delete; enrichment
-  // and import jobs support both.
-  const canCancel   = job.status === 'pending' || job.status === 'processing'
-  const canDelete   = !isAISuggestions && (job.status === 'done' || job.status === 'failed' || job.status === 'cancelled')
-  const isActive    = job.status === 'pending' || job.status === 'processing'
-  const isEnrichment = job.type === 'metadata' || job.type === 'cover'
-
-  // While an enrichment batch is expanded and still running, poll its items so
-  // the per-book status list updates in real time (same cadence as the parent poll).
-  useEffect(() => {
-    if (!expanded || !isEnrichment || !isActive) return
-    const refresh = () => {
-      callApi<{ items: EnrichmentItem[] }>(`/api/v1/enrichment-batches/${job.id}`)
-        .then(full => setEnrichItems(full.items ?? []))
-        .catch(() => {})
-    }
-    const id = setInterval(refresh, 3000)
-    return () => clearInterval(id)
-  }, [expanded, isEnrichment, isActive, job.id, callApi])
-
-  const toggleExpand = async () => {
-    const isEnr = job.type === 'metadata' || job.type === 'cover'
-    // AI suggestion runs expand into a RunDetailPanel, which self-fetches —
-    // skip the items lookup for that type.
-    if (!expanded && !isAISuggestions) {
-      setLoadingItems(true)
-      try {
-        if (isEnr) {
-          const full = await callApi<{ items: EnrichmentItem[] }>(`/api/v1/enrichment-batches/${job.id}`)
-          setEnrichItems(full.items ?? [])
-        } else if (items === null) {
-          const full = await callApi<Job>(`/api/v1/libraries/${job.library_id}/imports/${job.id}`)
-          setItems(full.items ?? [])
-        }
-      } catch {
-        if (isEnr) setEnrichItems([])
-        else setItems([])
-      } finally {
-        setLoadingItems(false)
-      }
-    }
-    setExpanded(e => !e)
-  }
-
-  const handleCancel = async (e: React.MouseEvent) => {
-    e.stopPropagation()
-    if (!canCancel || cancelling) return
-    setCancelling(true)
-    try {
-      if (isAISuggestions) {
-        await callApi(`/api/v1/admin/jobs/ai-suggestions/runs/${job.id}`, { method: 'DELETE' })
-      } else if (isEnrichment) {
-        await callApi(`/api/v1/enrichment-batches/${job.id}/cancel`, { method: 'POST' })
-      } else {
-        await callApi(`/api/v1/imports/${job.id}/cancel`, { method: 'POST' })
-      }
-      onCancelled(job.id)
-    } catch {
-      // non-fatal — parent will refresh
-    } finally {
-      setCancelling(false)
-    }
-  }
-
-  const handleDelete = async (e: React.MouseEvent) => {
-    e.stopPropagation()
-    if (!canDelete || deleting) return
-    setDeleting(true)
-    try {
-      const path = isEnrichment
-        ? `/api/v1/enrichment-batches/${job.id}`
-        : `/api/v1/imports/${job.id}`
-      await callApi(path, { method: 'DELETE' })
-      onDeleted(job.id)
-    } catch {
-      setDeleting(false)
-    }
-  }
-
-  const successRows = job.status === 'done'
-    ? Math.max(0, job.processed_rows - job.failed_rows - job.skipped_rows)
-    : null
-
-  return (
-    <div className="border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-      <button
-        onClick={toggleExpand}
-        className="w-full text-left px-5 py-4 bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
-      >
-        <div className="flex items-center gap-4">
-          <svg
-            className={`w-4 h-4 text-gray-400 flex-shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
-            fill="none" stroke="currentColor" viewBox="0 0 24 24"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-          </svg>
-
-          <div className="flex-1 min-w-0 grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-3">
-            <TypeBadge type={job.type} />
-            <StatusBadge status={job.status} />
-
-            <div className="min-w-0">
-              <div className="flex items-center gap-2 mb-0.5">
-                <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                  {isAISuggestions
-                    ? `Triggered by ${job.triggered_by ?? 'scheduler'}${job.user_id ? ` · user ${job.user_id.slice(0, 8)}` : ''}`
-                    : (job.library_name ?? job.library_id)}
-                </span>
-                <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
-                  {job.id.slice(0, 8)}
-                </span>
-              </div>
-              {isAISuggestions ? (
-                isActive ? (
-                  <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-                    <span className="inline-block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-                    <span>Running…</span>
-                    {job.provider_type && (
-                      <span className="text-gray-400">{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
-                    )}
-                  </div>
-                ) : (
-                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-500 dark:text-gray-400">
-                    {job.provider_type && (
-                      <span>{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
-                    )}
-                    {(job.tokens_in !== undefined || job.tokens_out !== undefined) && (
-                      <span className="tabular-nums">
-                        {formatTokens(job.tokens_in ?? 0)} in / {formatTokens(job.tokens_out ?? 0)} out
-                      </span>
-                    )}
-                    {job.estimated_cost_usd !== undefined && job.estimated_cost_usd > 0 && (
-                      <span className="tabular-nums">${job.estimated_cost_usd.toFixed(4)}</span>
-                    )}
-                    {formatDurationSec(job.created_at, job.finished_at) && (
-                      <span className="tabular-nums">{formatDurationSec(job.created_at, job.finished_at)}</span>
-                    )}
-                    {job.run_error && (
-                      <span className="text-red-600 dark:text-red-400 truncate max-w-xs" title={job.run_error}>
-                        {job.run_error}
-                      </span>
-                    )}
-                  </div>
-                )
-              ) : isActive ? (
-                <div className="flex items-center gap-2">
-                  <div className="flex-1 h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden max-w-xs">
-                    <div
-                      className="h-full rounded-full bg-blue-500 transition-all duration-500"
-                      style={{ width: job.total_rows > 0 ? `${Math.round((job.processed_rows / job.total_rows) * 100)}%` : '0%' }}
-                    />
-                  </div>
-                  <span className="text-xs text-gray-400 tabular-nums">
-                    {job.processed_rows}/{job.total_rows}
-                  </span>
-                </div>
-              ) : (
-                <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
-                  <span>{job.total_rows} {isEnrichment ? 'books' : 'rows'}</span>
-                  {successRows !== null && successRows > 0 && (
-                    <span className="text-green-600 dark:text-green-400">
-                      {successRows} {isEnrichment ? 'updated' : 'added'}
-                    </span>
-                  )}
-                  {job.skipped_rows > 0 && <span className="text-amber-600 dark:text-amber-400">{job.skipped_rows} skipped</span>}
-                  {job.failed_rows > 0 && <span className="text-red-600 dark:text-red-400">{job.failed_rows} failed</span>}
-                </div>
-              )}
-            </div>
-
-            <span className="text-xs text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
-              {formatDate(job.created_at)}
-            </span>
-
-            <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
-              {canCancel && (
-                <button
-                  onClick={handleCancel}
-                  disabled={cancelling}
-                  className="text-xs text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50 transition-colors px-1 py-0.5 rounded"
-                  title="Cancel job"
-                >
-                  {cancelling ? '…' : 'Cancel'}
-                </button>
-              )}
-              {canDelete && (
-                <button
-                  onClick={handleDelete}
-                  disabled={deleting}
-                  className="text-xs text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-50 transition-colors px-1 py-0.5 rounded"
-                  title="Delete job"
-                >
-                  {deleting ? '…' : 'Delete'}
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-      </button>
-
-      {expanded && (
-        <div className="border-t border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
-          {isAISuggestions ? (
-            <div className="px-5 py-4">
-              <RunDetailPanel
-                endpoint={`/api/v1/admin/jobs/ai-suggestions/runs/${job.id}`}
-                hideSummary
-              />
-            </div>
-          ) : loadingItems ? (
-            <div className="flex items-center justify-center py-8 text-sm text-gray-400 dark:text-gray-500">
-              <div className="w-4 h-4 rounded-full border-2 border-blue-500 border-t-transparent animate-spin mr-2" />
-              Loading…
-            </div>
-          ) : isEnrichment ? (
-            enrichItems && enrichItems.length > 0 ? (
-              <div className="divide-y divide-gray-100 dark:divide-gray-800">
-                {enrichItems.map(item => (
-                  <div key={item.id} className="flex items-start gap-3 px-5 py-2.5 text-sm">
-                    <ItemStatusDot status={item.status} />
-                    <div className="flex-1 min-w-0">
-                      <span className="text-gray-800 dark:text-gray-200 font-medium">
-                        {item.book_title || <span className="text-gray-400 italic font-mono text-xs">{item.book_id?.slice(0, 8) ?? 'Unknown'}</span>}
-                      </span>
-                      {item.message && (
-                        <p className={`text-xs mt-0.5 ${
-                          item.status === 'failed' ? 'text-red-600 dark:text-red-400'
-                            : item.status === 'skipped' ? 'text-amber-600 dark:text-amber-400'
-                            : 'text-gray-400 dark:text-gray-500'
-                        }`}>
-                          {item.message}
-                        </p>
-                      )}
-                    </div>
-                    {item.book_id && (
-                      <Link
-                        to={`/libraries/${job.library_id}/books/${item.book_id}`}
-                        className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex-shrink-0"
-                        onClick={e => e.stopPropagation()}
-                      >
-                        View
-                      </Link>
-                    )}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="px-5 py-4 text-sm text-gray-400 dark:text-gray-500">No items.</p>
-            )
-          ) : items && items.length > 0 ? (
-            <div className="divide-y divide-gray-100 dark:divide-gray-800">
-              {items.map(item => (
-                <div key={item.id} className="flex items-start gap-3 px-5 py-2.5 text-sm">
-                  <span className="text-xs tabular-nums text-gray-400 dark:text-gray-500 w-8 flex-shrink-0 pt-0.5 text-right">
-                    {item.row_number}
-                  </span>
-                  <ItemStatusDot status={item.status} />
-                  <div className="flex-1 min-w-0">
-                    <span className="text-gray-800 dark:text-gray-200 font-medium">
-                      {item.title || <span className="text-gray-400 italic">Untitled</span>}
-                    </span>
-                    {item.isbn && <span className="ml-2 text-xs text-gray-400 font-mono">{item.isbn}</span>}
-                    {item.message && (
-                      <p className={`text-xs mt-0.5 ${
-                        item.status === 'failed' ? 'text-red-600 dark:text-red-400'
-                          : item.status === 'skipped' ? 'text-amber-600 dark:text-amber-400'
-                          : 'text-gray-400 dark:text-gray-500'
-                      }`}>
-                        {item.message}
-                      </p>
-                    )}
-                  </div>
-                  {item.book_id && (
-                    <Link
-                      to={`/libraries/${job.library_id}/books/${item.book_id}`}
-                      className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex-shrink-0"
-                      onClick={e => e.stopPropagation()}
-                    >
-                      View
-                    </Link>
-                  )}
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="px-5 py-4 text-sm text-gray-400 dark:text-gray-500">No items.</p>
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ─── JobsPage ─────────────────────────────────────────────────────────────────
-
+// JobsPage is the jobs admin overview: a grid of cards, one per
+// schedulable kind. Non-schedulable kinds (imports / enrichment kicked
+// off by user actions) intentionally don't appear here — their rows
+// surface in /admin/settings/jobs/history but they have no settings
+// page. Click a card to drill into per-kind settings.
 export default function JobsPage() {
   const { callApi } = useAuth()
-  const [jobs, setJobs] = useState<Job[]>([])
-  const [loading, setLoading] = useState(true)
+  const [schedules, setSchedules] = useState<Schedule[] | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [clearingAll, setClearingAll] = useState(false)
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const burstTimers = useRef<Array<ReturnType<typeof setTimeout>>>([])
   usePageTitle('Jobs')
 
-  const loadJobs = async () => {
+  const load = useCallback(async () => {
+    setError(null)
     try {
-      // One fetch replaces the three-endpoint fanout — the unified
-      // /admin/jobs/history returns every kind in one paginated shape.
-      const resp = await callApi<{ items: UnifiedJobRow[]; total: number }>(
-        '/api/v1/admin/jobs/history?limit=200'
-      )
-      const merged = (resp?.items ?? []).map(unifiedToJob)
-      setJobs(merged)
+      const list = await callApi<Schedule[]>('/api/v1/admin/jobs/schedules')
+      setSchedules(list ?? [])
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load jobs')
-    } finally {
-      setLoading(false)
     }
-  }
+  }, [callApi])
 
-  useEffect(() => {
-    loadJobs()
-    return () => {
-      burstTimers.current.forEach(t => clearTimeout(t))
-      burstTimers.current = []
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  // AdminRunSuggestions enqueues River jobs asynchronously — the run rows
-  // don't exist until the worker picks them up. A single reload races the
-  // worker, so fire a short burst instead to catch the run once it lands.
-  const burstReload = () => {
-    burstTimers.current.forEach(t => clearTimeout(t))
-    burstTimers.current = []
-    loadJobs()
-    for (const delay of [600, 1500, 3000, 6000]) {
-      const t = setTimeout(loadJobs, delay)
-      burstTimers.current.push(t)
-    }
-  }
-
-  // Auto-poll while any job is active
-  useEffect(() => {
-    const hasActive = jobs.some(j => j.status === 'pending' || j.status === 'processing')
-    if (hasActive && !pollRef.current) {
-      pollRef.current = setInterval(loadJobs, 3000)
-    } else if (!hasActive && pollRef.current) {
-      clearInterval(pollRef.current)
-      pollRef.current = null
-    }
-    return () => { if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null } }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [jobs])
-
-  const handleCancelled = (id: string) => {
-    setJobs(prev => prev.map(j => j.id === id ? { ...j, status: 'cancelled' as JobStatus } : j))
-  }
-
-  const handleDeleted = (id: string) => {
-    setJobs(prev => prev.filter(j => j.id !== id))
-  }
-
-  const handleClearFinished = async () => {
-    if (clearingAll) return
-    setClearingAll(true)
-    try {
-      await Promise.all([
-        callApi('/api/v1/imports', { method: 'DELETE' }),
-        callApi('/api/v1/enrichment-batches', { method: 'DELETE' }),
-        callApi('/api/v1/admin/jobs/ai-suggestions/runs', { method: 'DELETE' }).catch(() => {}),
-      ])
-      setJobs(prev => prev.filter(j => j.status === 'pending' || j.status === 'processing'))
-    } catch {
-      // non-fatal
-    } finally {
-      setClearingAll(false)
-    }
-  }
-
-  const hasFinished = jobs.some(j => j.status === 'done' || j.status === 'failed' || j.status === 'cancelled')
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20 text-gray-400 dark:text-gray-500">
-        <div className="w-5 h-5 rounded-full border-2 border-blue-500 border-t-transparent animate-spin" />
-      </div>
-    )
-  }
+  useEffect(() => { load() }, [load])
 
   return (
     <>
       <PageHeader
         title="Jobs"
-        description="Background tasks across all libraries."
+        description="Scheduled background tasks. Click any job to configure or run."
         breadcrumbs={[{ label: 'Settings', to: '/admin/settings' }, { label: 'Jobs' }]}
-        actions={hasFinished ? (
-          <button
-            onClick={handleClearFinished}
-            disabled={clearingAll}
-            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:border-red-400 hover:text-red-600 dark:hover:border-red-500 dark:hover:text-red-400 disabled:opacity-50 transition-colors"
+        actions={
+          <Link
+            to="/admin/settings/jobs/history"
+            className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 transition-colors"
           >
-            {clearingAll ? 'Clearing…' : 'Clear finished'}
-          </button>
-        ) : undefined}
+            View history →
+          </Link>
+        }
       />
       <div className="p-8 max-w-4xl mx-auto">
+        {error && (
+          <div className="mb-6 rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        )}
 
-      {error && (
-        <div className="mb-6 rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
-          {error}
-        </div>
-      )}
-
-      <section className="mb-8">
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-          Schedules
-        </h2>
-        <JobSchedulesSection />
-      </section>
-
-      <section className="mb-8">
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-          AI suggestions config
-        </h2>
-        <AISuggestionsJobCard onRunKicked={burstReload} />
-      </section>
-
-      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-        History
-      </h2>
-
-      {jobs.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 p-12 text-center">
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">No jobs yet</p>
-          <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-            Start an import from the Import tool to see background jobs here.
-          </p>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {jobs.map(job => (
-            <JobRow
-              key={job.id}
-              job={job}
-              onCancelled={handleCancelled}
-              onDeleted={handleDeleted}
-            />
-          ))}
-        </div>
-      )}
-    </div>
+        {schedules === null ? (
+          <div className="text-sm text-gray-400 dark:text-gray-500">Loading…</div>
+        ) : schedules.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 p-12 text-center">
+            <p className="text-sm font-medium text-gray-500 dark:text-gray-400">No scheduled jobs registered</p>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {schedules.map(s => (
+              <JobOverviewCard key={s.kind} schedule={s} />
+            ))}
+          </div>
+        )}
+      </div>
     </>
+  )
+}
+
+function JobOverviewCard({ schedule }: { schedule: Schedule }) {
+  return (
+    <Link
+      to={`/admin/settings/jobs/${encodeURIComponent(schedule.kind)}`}
+      className="block rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 hover:border-blue-400 dark:hover:border-blue-600 transition-colors"
+    >
+      <div className="flex items-center justify-between gap-2 mb-1.5">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+          {schedule.display_name}
+        </h3>
+        <span className={`flex-shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+          schedule.enabled
+            ? 'bg-green-50 dark:bg-green-950/50 text-green-700 dark:text-green-400 ring-1 ring-green-200 dark:ring-green-800'
+            : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
+        }`}>
+          {schedule.enabled ? 'Enabled' : 'Disabled'}
+        </span>
+      </div>
+      {schedule.description && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2">{schedule.description}</p>
+      )}
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-400 dark:text-gray-500">
+        <span className="font-mono">{schedule.cron}</span>
+        {schedule.last_fired_at && (
+          <span>Last fired {new Date(schedule.last_fired_at).toLocaleString()}</span>
+        )}
+      </div>
+    </Link>
   )
 }

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -2,13 +2,16 @@
 // Copyright (C) 2026 fireball1725
 
 import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import PageHeader from '../../components/PageHeader'
+import { useToast } from '../../components/Toast'
 import { usePageTitle } from '../../hooks/usePageTitle'
 
 // Schedule is the wire-shape returned by GET /admin/jobs/schedules —
-// one row per registered schedulable kind.
+// one row per registered schedulable kind. next_fire_at is computed
+// server-side from the cron + last_fired_at; empty when the schedule
+// is disabled.
 interface Schedule {
   id: string
   kind: string
@@ -17,17 +20,21 @@ interface Schedule {
   cron: string
   enabled: boolean
   last_fired_at?: string
+  next_fire_at?: string
 }
 
-// JobsPage is the jobs admin overview: a grid of cards, one per
-// schedulable kind. Non-schedulable kinds (imports / enrichment kicked
-// off by user actions) intentionally don't appear here — their rows
-// surface in /admin/settings/jobs/history but they have no settings
-// page. Click a card to drill into per-kind settings.
+// JobsPage is the jobs admin overview: a table of schedulable kinds with
+// inline enabled toggles and a live countdown to the next run. Click a
+// row or the edit button to drill into per-kind settings. Non-schedulable
+// kinds (imports / enrichment) don't appear here — they surface in
+// /admin/settings/jobs/history but have no settings page.
 export default function JobsPage() {
   const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const navigate = useNavigate()
   const [schedules, setSchedules] = useState<Schedule[] | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [now, setNow] = useState(() => Date.now())
   usePageTitle('Jobs')
 
   const load = useCallback(async () => {
@@ -42,22 +49,46 @@ export default function JobsPage() {
 
   useEffect(() => { load() }, [load])
 
+  // Tick once a second so the "next run in X" column counts down in
+  // real time. One interval covers every row — cheaper than per-row
+  // timers.
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const toggleEnabled = async (s: Schedule, enabled: boolean) => {
+    try {
+      await callApi(`/api/v1/admin/jobs/schedules/${encodeURIComponent(s.kind)}`, {
+        method: 'PUT',
+        body: JSON.stringify({ cron: s.cron, enabled, config: {} }),
+      })
+      showToast(
+        enabled ? `${s.display_name} enabled` : `${s.display_name} disabled`,
+        { variant: 'success' },
+      )
+      load()
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to save', { variant: 'error' })
+    }
+  }
+
   return (
     <>
       <PageHeader
         title="Jobs"
-        description="Scheduled background tasks. Click any job to configure or run."
+        description="Scheduled background tasks."
         breadcrumbs={[{ label: 'Settings', to: '/admin/settings' }, { label: 'Jobs' }]}
         actions={
           <Link
             to="/admin/settings/jobs/history"
             className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 transition-colors"
           >
-            View history →
+            History
           </Link>
         }
       />
-      <div className="p-8 max-w-4xl mx-auto">
+      <div className="p-8 max-w-5xl mx-auto">
         {error && (
           <div className="mb-6 rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
             {error}
@@ -71,10 +102,63 @@ export default function JobsPage() {
             <p className="text-sm font-medium text-gray-500 dark:text-gray-400">No scheduled jobs registered</p>
           </div>
         ) : (
-          <div className="grid gap-3 sm:grid-cols-2">
-            {schedules.map(s => (
-              <JobOverviewCard key={s.kind} schedule={s} />
-            ))}
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+                <tr>
+                  {['Name', 'Cron', 'Next run', 'Enabled', ''].map(h => (
+                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {schedules.map(s => (
+                  <tr
+                    key={s.kind}
+                    onClick={() => navigate(`/admin/settings/jobs/${encodeURIComponent(s.kind)}`)}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
+                  >
+                    <td className="px-4 py-3">
+                      <p className="font-medium text-gray-900 dark:text-white">{s.display_name}</p>
+                      {s.description && (
+                        <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
+                          {s.description}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                      {s.cron}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                      {s.enabled && s.next_fire_at
+                        ? formatCountdown(new Date(s.next_fire_at).getTime() - now)
+                        : <span className="text-gray-300 dark:text-gray-600">—</span>}
+                    </td>
+                    <td className="px-4 py-3" onClick={e => e.stopPropagation()}>
+                      <label className="relative inline-flex items-center cursor-pointer">
+                        <input
+                          type="checkbox"
+                          className="sr-only peer"
+                          checked={s.enabled}
+                          onChange={e => toggleEnabled(s, e.target.checked)}
+                        />
+                        <div className="w-9 h-5 bg-gray-200 dark:bg-gray-600 rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full" />
+                      </label>
+                    </td>
+                    <td className="px-4 py-3 text-right" onClick={e => e.stopPropagation()}>
+                      <Link
+                        to={`/admin/settings/jobs/${encodeURIComponent(s.kind)}`}
+                        className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                      >
+                        Edit
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>
@@ -82,33 +166,21 @@ export default function JobsPage() {
   )
 }
 
-function JobOverviewCard({ schedule }: { schedule: Schedule }) {
-  return (
-    <Link
-      to={`/admin/settings/jobs/${encodeURIComponent(schedule.kind)}`}
-      className="block rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 hover:border-blue-400 dark:hover:border-blue-600 transition-colors"
-    >
-      <div className="flex items-center justify-between gap-2 mb-1.5">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
-          {schedule.display_name}
-        </h3>
-        <span className={`flex-shrink-0 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-          schedule.enabled
-            ? 'bg-green-50 dark:bg-green-950/50 text-green-700 dark:text-green-400 ring-1 ring-green-200 dark:ring-green-800'
-            : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
-        }`}>
-          {schedule.enabled ? 'Enabled' : 'Disabled'}
-        </span>
-      </div>
-      {schedule.description && (
-        <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2">{schedule.description}</p>
-      )}
-      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-400 dark:text-gray-500">
-        <span className="font-mono">{schedule.cron}</span>
-        {schedule.last_fired_at && (
-          <span>Last fired {new Date(schedule.last_fired_at).toLocaleString()}</span>
-        )}
-      </div>
-    </Link>
-  )
+// formatCountdown turns milliseconds-until-fire into a compact
+// "3h 10m 42s" string. Drops larger units when they'd be zero and
+// collapses to "due now" when the fire time has passed (shouldn't
+// normally happen — the scheduler tick handles it — but defensive).
+function formatCountdown(ms: number): string {
+  if (ms <= 0) return 'due now'
+  const totalSecs = Math.floor(ms / 1000)
+  const days = Math.floor(totalSecs / 86400)
+  const hrs  = Math.floor((totalSecs % 86400) / 3600)
+  const mins = Math.floor((totalSecs % 3600) / 60)
+  const secs = totalSecs % 60
+  const parts: string[] = []
+  if (days > 0)               parts.push(`${days}d`)
+  if (days > 0 || hrs  > 0)   parts.push(`${hrs}h`)
+  if (days > 0 || hrs > 0 || mins > 0) parts.push(`${mins}m`)
+  parts.push(`${secs}s`)
+  return 'in ' + parts.join(' ')
 }

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -8,6 +8,20 @@ import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { usePageTitle } from '../../hooks/usePageTitle'
 
+// Icon set kept alongside the page — single-use SVGs that don't deserve
+// their own file. Edit mirrors what BookPage uses for edition edit; Run
+// is a solid play triangle so it reads as an action separate from edit.
+const EditIcon = () => (
+  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+  </svg>
+)
+const RunIcon = () => (
+  <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+    <path d="M8 5v14l11-7z" />
+  </svg>
+)
+
 // Schedule is the wire-shape returned by GET /admin/jobs/schedules —
 // one row per registered schedulable kind. next_fire_at is computed
 // server-side from the cron + last_fired_at; empty when the schedule
@@ -73,6 +87,19 @@ export default function JobsPage() {
     }
   }
 
+  const runNow = async (s: Schedule) => {
+    try {
+      await callApi(`/api/v1/admin/jobs/schedules/${encodeURIComponent(s.kind)}/run`, {
+        method: 'POST',
+      })
+      showToast(`${s.display_name} run queued`, { variant: 'success' })
+      // Short delay then refresh so last_fired_at updates on the row.
+      setTimeout(load, 1500)
+    } catch (err) {
+      showToast(err instanceof ApiError ? err.message : 'Failed to run', { variant: 'error' })
+    }
+  }
+
   return (
     <>
       <PageHeader
@@ -88,7 +115,7 @@ export default function JobsPage() {
           </Link>
         }
       />
-      <div className="p-8 max-w-5xl mx-auto">
+      <div className="max-w-3xl px-8 py-8 space-y-6">
         {error && (
           <div className="mb-6 rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
             {error}
@@ -147,13 +174,24 @@ export default function JobsPage() {
                         <div className="w-9 h-5 bg-gray-200 dark:bg-gray-600 rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full" />
                       </label>
                     </td>
-                    <td className="px-4 py-3 text-right" onClick={e => e.stopPropagation()}>
-                      <Link
-                        to={`/admin/settings/jobs/${encodeURIComponent(s.kind)}`}
-                        className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
-                      >
-                        Edit
-                      </Link>
+                    <td className="px-4 py-3" onClick={e => e.stopPropagation()}>
+                      <div className="flex items-center gap-1 justify-end">
+                        <button
+                          type="button"
+                          onClick={() => runNow(s)}
+                          title="Run now"
+                          className="p-1.5 rounded-md text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                        >
+                          <RunIcon />
+                        </button>
+                        <Link
+                          to={`/admin/settings/jobs/${encodeURIComponent(s.kind)}`}
+                          title="Edit"
+                          className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                        >
+                          <EditIcon />
+                        </Link>
+                      </div>
                     </td>
                   </tr>
                 ))}

--- a/src/pages/jobs/JobsPage.tsx
+++ b/src/pages/jobs/JobsPage.tsx
@@ -7,8 +7,8 @@ import { useAuth, ApiError } from '../../auth/AuthContext'
 import PageHeader from '../../components/PageHeader'
 import RunDetailPanel from '../../components/RunDetailPanel'
 import { usePageTitle } from '../../hooks/usePageTitle'
-import type { SuggestionRunView } from '../../types'
 import AISuggestionsJobCard from './AISuggestionsJobCard'
+import JobSchedulesSection from './JobSchedulesSection'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -59,69 +59,74 @@ interface Job {
   finished_at?: string
 }
 
-// Raw shape returned by the enrichment-batches endpoint
-interface EnrichmentBatchRaw {
+// UnifiedJobRow mirrors the JobView the unified /admin/jobs/history
+// endpoint returns. Progress is a kind-specific JSON blob the umbrella
+// row holds for summary UI — counters extracted via unifiedToJob below.
+interface UnifiedJobRow {
   id: string
-  library_id: string
-  library_name?: string
-  type: 'metadata' | 'cover'
-  status: JobStatus
-  total_books: number
-  processed_books: number
-  failed_books: number
-  skipped_books: number
+  kind: string
+  status: string
+  triggered_by: string
+  created_by?: string | null
+  schedule_id?: string | null
+  error?: string
+  progress: Record<string, unknown>
+  started_at?: string | null
+  finished_at?: string | null
   created_at: string
   updated_at: string
 }
 
-function batchToJob(b: EnrichmentBatchRaw): Job {
+// unifiedToJob folds the umbrella row + kind-specific progress into the
+// page-local Job shape so the existing per-kind rendering still works.
+function unifiedToJob(u: UnifiedJobRow): Job {
+  const mappedStatus: JobStatus =
+    u.status === 'pending' ? 'pending'
+      : u.status === 'running' ? 'processing'
+      : u.status === 'completed' ? 'done'
+      : u.status === 'failed' ? 'failed'
+      : u.status === 'cancelled' ? 'cancelled'
+      : 'pending'
+
+  // Kind-specific counters live in progress as { processed, failed, skipped, total }
+  // for import and enrichment; AI suggestions writes { tokens_in, tokens_out, cost_usd }.
+  const p = u.progress ?? {}
+  const num = (k: string): number => {
+    const v = p[k]
+    return typeof v === 'number' ? v : 0
+  }
+
+  let jobType: JobType
+  switch (u.kind) {
+    case 'import':         jobType = 'import'; break
+    case 'enrichment':     jobType = 'metadata'; break
+    case 'ai_suggestions': jobType = 'ai_suggestions'; break
+    default:               jobType = 'metadata'; break
+  }
+
   return {
-    id: b.id,
-    type: b.type,
-    library_id: b.library_id,
-    library_name: b.library_name,
-    status: b.status,
-    total_rows: b.total_books,
-    processed_rows: b.processed_books,
-    failed_rows: b.failed_books,
-    skipped_rows: b.skipped_books,
-    created_at: b.created_at,
-    updated_at: b.updated_at,
+    id: u.id,
+    type: jobType,
+    library_id: '', // umbrella rows don't carry library_id; the per-kind
+                   // detail fetch still does when the UI needs it
+    status: mappedStatus,
+    total_rows: num('total'),
+    processed_rows: num('processed'),
+    failed_rows: num('failed'),
+    skipped_rows: num('skipped'),
+    created_at: u.created_at,
+    updated_at: u.updated_at,
+    triggered_by: u.triggered_by,
+    tokens_in: num('tokens_in'),
+    tokens_out: num('tokens_out'),
+    estimated_cost_usd: typeof p.cost_usd === 'number' ? (p.cost_usd as number) : 0,
+    run_error: u.error || undefined,
+    finished_at: u.finished_at || undefined,
   }
 }
 
-// runToJob folds a suggestion run into the Job shape so it sits alongside
-// imports and enrichment batches in the unified history list.
-function runToJob(r: SuggestionRunView): Job {
-  const status: JobStatus =
-    r.status === 'running' ? 'processing'
-      : r.status === 'completed' ? 'done'
-      : r.status === 'failed' ? 'failed'
-      : r.status === 'cancelled' ? 'cancelled'
-      : 'pending'
-  return {
-    id: r.id,
-    type: 'ai_suggestions',
-    library_id: '',
-    library_name: 'AI suggestions',
-    status,
-    total_rows: 0,
-    processed_rows: 0,
-    failed_rows: 0,
-    skipped_rows: 0,
-    created_at: r.started_at,
-    updated_at: r.finished_at ?? r.started_at,
-    triggered_by: r.triggered_by,
-    provider_type: r.provider_type,
-    model_id: r.model_id,
-    tokens_in: r.tokens_in,
-    tokens_out: r.tokens_out,
-    estimated_cost_usd: r.estimated_cost_usd,
-    user_id: r.user_id,
-    run_error: r.error,
-    finished_at: r.finished_at,
-  }
-}
+// Legacy batchToJob / runToJob helpers removed with the unified history
+// endpoint — unifiedToJob above handles every kind now.
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -515,20 +520,12 @@ export default function JobsPage() {
 
   const loadJobs = async () => {
     try {
-      const [importData, batchData, runData] = await Promise.all([
-        callApi<Job[]>('/api/v1/imports'),
-        callApi<EnrichmentBatchRaw[]>('/api/v1/enrichment-batches'),
-        // Suggestion runs are admin-only — tolerate failure so non-admins
-        // (if they ever reach this page) still see imports/enrichment.
-        callApi<SuggestionRunView[]>('/api/v1/admin/jobs/ai-suggestions/runs').catch(() => []),
-      ])
-      const imports = (importData ?? []).map(j => ({ ...j, type: 'import' as JobType }))
-      const batches = (batchData ?? []).map(batchToJob)
-      const runs = (runData ?? []).map(runToJob)
-      // Merge and sort newest-first
-      const merged = [...imports, ...batches, ...runs].sort(
-        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      // One fetch replaces the three-endpoint fanout — the unified
+      // /admin/jobs/history returns every kind in one paginated shape.
+      const resp = await callApi<{ items: UnifiedJobRow[]; total: number }>(
+        '/api/v1/admin/jobs/history?limit=200'
       )
+      const merged = (resp?.items ?? []).map(unifiedToJob)
       setJobs(merged)
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load jobs')
@@ -633,7 +630,14 @@ export default function JobsPage() {
 
       <section className="mb-8">
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-          Scheduled jobs
+          Schedules
+        </h2>
+        <JobSchedulesSection />
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+          AI suggestions config
         </h2>
         <AISuggestionsJobCard onRunKicked={burstReload} />
       </section>


### PR DESCRIPTION
- JobsPage consumes the new \`/admin/jobs/history\` endpoint in a single fetch; \`unifiedToJob\` maps umbrella + kind-specific progress into the existing per-kind rendering.
- New Schedules section uses [react-js-cron](https://www.npmjs.com/package/react-js-cron) for editing cron expressions. Enabled toggle + Save/Reset per row. AISuggestionsJobCard loses its cadence dropdown (cron owns that now); \`interval_minutes\` stays as a per-user cooldown gate.