### PR TITLE
feat(profile): tab layout + API tokens

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,398 +1,52 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 fireball1725
 
-import { useEffect, useState } from 'react'
-import type { FormEvent } from 'react'
-import { useTranslation } from 'react-i18next'
-import { useAuth } from '../auth/AuthContext'
-import { useToast } from '../components/Toast'
-import TasteProfileForm from '../components/TasteProfileForm'
-import type { User, UserAIPrefs } from '../types'
-import { LOCALE_FLAGS, LOCALE_LABELS, LOCALE_STORAGE_KEY, SUPPORTED_LOCALES, type SupportedLocale } from '../i18n'
+import { useState } from 'react'
+import AccountTab from './profile/AccountTab'
+import PreferencesTab from './profile/PreferencesTab'
+import AITab from './profile/AITab'
+import ApiTokensTab from './profile/ApiTokensTab'
 
-// ─── Reusable field row ───────────────────────────────────────────────────────
+type Tab = 'account' | 'preferences' | 'ai' | 'api-tokens'
 
-function FieldRow({ label, htmlFor, children }: { label: string; htmlFor?: string; children: React.ReactNode }) {
-  return (
-    <div className="px-6 py-4">
-      <label
-        className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1"
-        htmlFor={htmlFor}
-      >
-        {label}
-      </label>
-      {children}
-    </div>
-  )
-}
-
-const inputClass =
-  'w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60'
-
-// ─── Page ─────────────────────────────────────────────────────────────────────
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'account',     label: 'Account' },
+  { id: 'preferences', label: 'Preferences' },
+  { id: 'ai',          label: 'AI' },
+  { id: 'api-tokens',  label: 'API tokens' },
+]
 
 export default function ProfilePage() {
-  const { user, callApi, updateUser } = useAuth()
-  const { show: showToast } = useToast()
-  const { i18n } = useTranslation()
-
-  const currentLocale: SupportedLocale = (SUPPORTED_LOCALES as readonly string[]).includes(i18n.resolvedLanguage ?? '')
-    ? (i18n.resolvedLanguage as SupportedLocale)
-    : 'en-CA'
-
-  const handleLocaleChange = async (locale: SupportedLocale) => {
-    await i18n.changeLanguage(locale)
-    localStorage.setItem(LOCALE_STORAGE_KEY, locale)
-  }
-
-  // ── Profile section ─────────────────────────────────────────────────────────
-
-  const [displayName, setDisplayName] = useState(user?.display_name ?? '')
-  const [email, setEmail] = useState(user?.email ?? '')
-  const [profileSaving, setProfileSaving] = useState(false)
-
-  // Sync if the user object updates externally (e.g. token refresh)
-  useEffect(() => {
-    if (user) {
-      setDisplayName(user.display_name)
-      setEmail(user.email)
-    }
-  }, [user?.id]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleProfileSave = async (e: FormEvent) => {
-    e.preventDefault()
-    const trimmedName = displayName.trim()
-    const trimmedEmail = email.trim()
-    if (!trimmedName || !trimmedEmail) return
-    setProfileSaving(true)
-    try {
-      const updated = await callApi<User>('/api/v1/auth/me', {
-        method: 'PUT',
-        body: JSON.stringify({ display_name: trimmedName, email: trimmedEmail }),
-      })
-      updateUser(updated)
-      showToast('Profile updated', { variant: 'success' })
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to update profile', { variant: 'error' })
-    } finally {
-      setProfileSaving(false)
-    }
-  }
-
-  // ── Password section ────────────────────────────────────────────────────────
-
-  const [currentPassword, setCurrentPassword] = useState('')
-  const [newPassword, setNewPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
-  const [passwordSaving, setPasswordSaving] = useState(false)
-
-  const handlePasswordChange = async (e: FormEvent) => {
-    e.preventDefault()
-    if (newPassword !== confirmPassword) {
-      showToast('New passwords do not match', { variant: 'error' })
-      return
-    }
-    if (newPassword.length < 8) {
-      showToast('Password must be at least 8 characters', { variant: 'error' })
-      return
-    }
-    setPasswordSaving(true)
-    try {
-      await callApi('/api/v1/auth/me/password', {
-        method: 'PUT',
-        body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
-      })
-      showToast('Password changed', { variant: 'success' })
-      setCurrentPassword('')
-      setNewPassword('')
-      setConfirmPassword('')
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to change password', { variant: 'error' })
-    } finally {
-      setPasswordSaving(false)
-    }
-  }
-
-  // ── Preferences section ─────────────────────────────────────────────────────
-
-  const [showReadBadges, setShowReadBadges] = useState(true)
-  const [prefsLoading, setPrefsLoading] = useState(true)
-
-  useEffect(() => {
-    callApi<{ prefs: Record<string, unknown> }>('/api/v1/auth/me/preferences')
-      .then(({ prefs }) => {
-        const rb = prefs['show_read_badges']
-        if (typeof rb === 'boolean') setShowReadBadges(rb)
-      })
-      .catch(() => {})
-      .finally(() => setPrefsLoading(false))
-  }, [callApi])
-
-  const handleToggle = async (key: string, value: boolean) => {
-    if (key === 'show_read_badges') setShowReadBadges(value)
-    localStorage.setItem(`librarium:${key}`, String(value))
-    try {
-      await callApi('/api/v1/auth/me/preferences', {
-        method: 'PATCH',
-        body: JSON.stringify({ [key]: value }),
-      })
-    } catch {
-      showToast('Failed to save preference', { variant: 'error' })
-      if (key === 'show_read_badges') setShowReadBadges(!value)
-    }
-  }
-
-  // ── AI preferences section ─────────────────────────────────────────────────
-
-  const [aiOptIn, setAiOptIn] = useState(false)
-  const [aiPrefsLoading, setAiPrefsLoading] = useState(true)
-  const [aiOptInSaving, setAiOptInSaving] = useState(false)
-
-  useEffect(() => {
-    callApi<UserAIPrefs>('/api/v1/me/ai-prefs')
-      .then(p => setAiOptIn(Boolean(p?.opt_in)))
-      .catch(() => {})
-      .finally(() => setAiPrefsLoading(false))
-  }, [callApi])
-
-  const handleAiOptInToggle = async (next: boolean) => {
-    setAiOptInSaving(true)
-    try {
-      await callApi('/api/v1/me/ai-prefs', {
-        method: 'PUT',
-        body: JSON.stringify({ opt_in: next }),
-      })
-      setAiOptIn(next)
-      // Notify the sidebar so the Suggestions link shows/hides without reload.
-      window.dispatchEvent(new Event('librarium:ai-prefs-changed'))
-    } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to update AI preferences', { variant: 'error' })
-    } finally {
-      setAiOptInSaving(false)
-    }
-  }
-
-  // ── Render ──────────────────────────────────────────────────────────────────
-
-  const cardClass =
-    'rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-800'
-
-  const sectionHeading = (label: string) => (
-    <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-3">
-      {label}
-    </h2>
-  )
+  const [tab, setTab] = useState<Tab>('account')
 
   return (
     <div className="px-6 py-8">
-      <div className="max-w-2xl mx-auto space-y-10">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Profile &amp; Preferences</h1>
+      <div className="max-w-2xl mx-auto">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">Profile &amp; Preferences</h1>
 
-        {/* ── Profile ── */}
-        <section>
-          {sectionHeading('Profile')}
-          <form onSubmit={handleProfileSave} className={cardClass}>
-            <FieldRow label="Username">
-              <p className="text-sm text-gray-700 dark:text-gray-300">{user?.username}</p>
-            </FieldRow>
-
-            <FieldRow label="Display name" htmlFor="display-name">
-              <input
-                id="display-name"
-                type="text"
-                value={displayName}
-                onChange={e => setDisplayName(e.target.value)}
-                autoComplete="name"
-                className={inputClass}
-              />
-            </FieldRow>
-
-            <FieldRow label="Email" htmlFor="email">
-              <input
-                id="email"
-                type="email"
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-                autoComplete="email"
-                className={inputClass}
-              />
-            </FieldRow>
-
-            <div className="px-6 py-4 flex justify-end">
+        <div className="border-b border-gray-200 dark:border-gray-800 mb-8">
+          <nav className="flex gap-6 -mb-px">
+            {TABS.map(t => (
               <button
-                type="submit"
-                disabled={profileSaving || !displayName.trim() || !email.trim()}
-                className="px-4 py-1.5 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                className={`whitespace-nowrap pb-3 text-sm font-medium transition-colors border-b-2 ${
+                  tab === t.id
+                    ? 'border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-700'
+                }`}
               >
-                {profileSaving ? 'Saving…' : 'Save changes'}
+                {t.label}
               </button>
-            </div>
-          </form>
-        </section>
+            ))}
+          </nav>
+        </div>
 
-        {/* ── Security ── */}
-        <section>
-          {sectionHeading('Security')}
-          <form onSubmit={handlePasswordChange} className={cardClass}>
-            <FieldRow label="Current password" htmlFor="current-password">
-              <input
-                id="current-password"
-                type="password"
-                value={currentPassword}
-                onChange={e => setCurrentPassword(e.target.value)}
-                autoComplete="current-password"
-                className={inputClass}
-              />
-            </FieldRow>
-
-            <FieldRow label="New password" htmlFor="new-password">
-              <input
-                id="new-password"
-                type="password"
-                value={newPassword}
-                onChange={e => setNewPassword(e.target.value)}
-                autoComplete="new-password"
-                className={inputClass}
-              />
-            </FieldRow>
-
-            <FieldRow label="Confirm new password" htmlFor="confirm-password">
-              <input
-                id="confirm-password"
-                type="password"
-                value={confirmPassword}
-                onChange={e => setConfirmPassword(e.target.value)}
-                autoComplete="new-password"
-                className={inputClass}
-              />
-            </FieldRow>
-
-            <div className="px-6 py-4 flex justify-end">
-              <button
-                type="submit"
-                disabled={passwordSaving || !currentPassword || !newPassword || !confirmPassword}
-                className="px-4 py-1.5 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
-              >
-                {passwordSaving ? 'Updating…' : 'Change password'}
-              </button>
-            </div>
-          </form>
-        </section>
-
-        {/* ── Language ── */}
-        <section>
-          {sectionHeading('Language')}
-          <div className={cardClass}>
-            <div className="flex items-center justify-between px-6 py-4 gap-6">
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-gray-900 dark:text-white">Interface language</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  Switches the language used throughout the web interface.
-                </p>
-              </div>
-              <select
-                value={currentLocale}
-                onChange={e => handleLocaleChange(e.target.value as SupportedLocale)}
-                className="flex-shrink-0 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                {SUPPORTED_LOCALES.map(locale => (
-                  <option key={locale} value={locale}>
-                    {LOCALE_FLAGS[locale]}  {LOCALE_LABELS[locale]}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-        </section>
-
-        {/* ── AI Privacy ── */}
-        <section>
-          {sectionHeading('AI Privacy')}
-          <div className={cardClass}>
-            <div className="flex items-center justify-between px-6 py-4">
-              <div className="min-w-0 mr-6">
-                <p className="text-sm font-medium text-gray-900 dark:text-white">Allow AI features to use my data</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  When on, AI-powered suggestions may read categories the admin has allowed
-                  (reading history, ratings, favourites, full library, and your taste profile
-                  below). Turning this off disables AI suggestions for you entirely.
-                </p>
-              </div>
-              {aiPrefsLoading ? (
-                <div className="h-6 w-11 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => handleAiOptInToggle(!aiOptIn)}
-                  disabled={aiOptInSaving}
-                  className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
-                    aiOptIn ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'
-                  } disabled:opacity-60`}
-                  role="switch"
-                  aria-checked={aiOptIn}
-                  aria-label="Allow AI features"
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
-                      aiOptIn ? 'translate-x-6' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              )}
-            </div>
-          </div>
-        </section>
-
-        {/* ── Taste profile ── */}
-        <section>
-          {sectionHeading('Taste profile')}
-          <p className="mb-3 -mt-2 text-xs text-gray-500 dark:text-gray-400">
-            Optional. Helps the AI generate more personal suggestions. All fields are optional — empty
-            categories aren't sent.
-            {!aiOptIn && !aiPrefsLoading && (
-              <span className="ml-1 text-amber-600 dark:text-amber-400">
-                You haven't opted in to AI features, so this profile won't be used.
-              </span>
-            )}
-          </p>
-          <TasteProfileForm />
-        </section>
-
-        {/* ── Display preferences ── */}
-        <section>
-          {sectionHeading('Display')}
-          <div className={cardClass}>
-            <div className="flex items-center justify-between px-6 py-4">
-              <div className="min-w-0 mr-6">
-                <p className="text-sm font-medium text-gray-900 dark:text-white">Show read status badges</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  Show a coloured corner badge on book covers indicating your read status
-                  (read, reading, did not finish)
-                </p>
-              </div>
-              {prefsLoading ? (
-                <div className="h-6 w-11 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => handleToggle('show_read_badges', !showReadBadges)}
-                  className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
-                    showReadBadges ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'
-                  }`}
-                  role="switch"
-                  aria-checked={showReadBadges}
-                  aria-label="Show read status badges"
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
-                      showReadBadges ? 'translate-x-6' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              )}
-            </div>
-          </div>
-        </section>
+        {tab === 'account'     && <AccountTab />}
+        {tab === 'preferences' && <PreferencesTab />}
+        {tab === 'ai'          && <AITab />}
+        {tab === 'api-tokens'  && <ApiTokensTab />}
       </div>
     </div>
   )

--- a/src/pages/profile/AITab.tsx
+++ b/src/pages/profile/AITab.tsx
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useState } from 'react'
+import { useAuth } from '../../auth/AuthContext'
+import { useToast } from '../../components/Toast'
+import TasteProfileForm from '../../components/TasteProfileForm'
+import type { UserAIPrefs } from '../../types'
+import { SectionHeading, cardClass } from './shared'
+
+// AITab hosts the AI opt-in toggle and the taste profile — both relate to
+// how the suggestions feature uses the user's data.
+export default function AITab() {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+
+  const [aiOptIn, setAiOptIn] = useState(false)
+  const [aiPrefsLoading, setAiPrefsLoading] = useState(true)
+  const [aiOptInSaving, setAiOptInSaving] = useState(false)
+
+  useEffect(() => {
+    callApi<UserAIPrefs>('/api/v1/me/ai-prefs')
+      .then(p => setAiOptIn(Boolean(p?.opt_in)))
+      .catch(() => {})
+      .finally(() => setAiPrefsLoading(false))
+  }, [callApi])
+
+  const handleAiOptInToggle = async (next: boolean) => {
+    setAiOptInSaving(true)
+    try {
+      await callApi('/api/v1/me/ai-prefs', {
+        method: 'PUT',
+        body: JSON.stringify({ opt_in: next }),
+      })
+      setAiOptIn(next)
+      // Notify the sidebar so the Suggestions link shows/hides without reload.
+      window.dispatchEvent(new Event('librarium:ai-prefs-changed'))
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update AI preferences', { variant: 'error' })
+    } finally {
+      setAiOptInSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <SectionHeading label="AI privacy" />
+        <div className={cardClass}>
+          <div className="flex items-center justify-between px-6 py-4">
+            <div className="min-w-0 mr-6">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">Allow AI features to use my data</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                When on, AI-powered suggestions may read categories the admin has allowed
+                (reading history, ratings, favourites, full library, and your taste profile
+                below). Turning this off disables AI suggestions for you entirely.
+              </p>
+            </div>
+            {aiPrefsLoading ? (
+              <div className="h-6 w-11 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
+            ) : (
+              <button
+                type="button"
+                onClick={() => handleAiOptInToggle(!aiOptIn)}
+                disabled={aiOptInSaving}
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+                  aiOptIn ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'
+                } disabled:opacity-60`}
+                role="switch"
+                aria-checked={aiOptIn}
+                aria-label="Allow AI features"
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                    aiOptIn ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <SectionHeading label="Taste profile" />
+        <p className="mb-3 -mt-2 text-xs text-gray-500 dark:text-gray-400">
+          Optional. Helps the AI generate more personal suggestions. All fields are optional;
+          empty categories aren't sent.
+          {!aiOptIn && !aiPrefsLoading && (
+            <span className="ml-1 text-amber-600 dark:text-amber-400">
+              You haven't opted in to AI features, so this profile won't be used.
+            </span>
+          )}
+        </p>
+        <TasteProfileForm />
+      </section>
+    </div>
+  )
+}

--- a/src/pages/profile/AccountTab.tsx
+++ b/src/pages/profile/AccountTab.tsx
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useState, type FormEvent } from 'react'
+import { useAuth } from '../../auth/AuthContext'
+import { useToast } from '../../components/Toast'
+import type { User } from '../../types'
+import { FieldRow, SectionHeading, buttonPrimaryClass, cardClass, inputClass } from './shared'
+
+// AccountTab combines the original "Profile" and "Security" sections — both
+// are identity-related and belong on the same surface. Username + display
+// name + email live here, as does the change-password form.
+export default function AccountTab() {
+  const { user, callApi, updateUser } = useAuth()
+  const { show: showToast } = useToast()
+
+  // ── Profile form ──
+  const [displayName, setDisplayName] = useState(user?.display_name ?? '')
+  const [email, setEmail] = useState(user?.email ?? '')
+  const [profileSaving, setProfileSaving] = useState(false)
+
+  useEffect(() => {
+    if (user) {
+      setDisplayName(user.display_name)
+      setEmail(user.email)
+    }
+  }, [user?.id]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleProfileSave = async (e: FormEvent) => {
+    e.preventDefault()
+    const trimmedName = displayName.trim()
+    const trimmedEmail = email.trim()
+    if (!trimmedName || !trimmedEmail) return
+    setProfileSaving(true)
+    try {
+      const updated = await callApi<User>('/api/v1/auth/me', {
+        method: 'PUT',
+        body: JSON.stringify({ display_name: trimmedName, email: trimmedEmail }),
+      })
+      updateUser(updated)
+      showToast('Profile updated', { variant: 'success' })
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to update profile', { variant: 'error' })
+    } finally {
+      setProfileSaving(false)
+    }
+  }
+
+  // ── Password form ──
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [passwordSaving, setPasswordSaving] = useState(false)
+
+  const handlePasswordChange = async (e: FormEvent) => {
+    e.preventDefault()
+    if (newPassword !== confirmPassword) {
+      showToast('New passwords do not match', { variant: 'error' })
+      return
+    }
+    if (newPassword.length < 8) {
+      showToast('Password must be at least 8 characters', { variant: 'error' })
+      return
+    }
+    setPasswordSaving(true)
+    try {
+      await callApi('/api/v1/auth/me/password', {
+        method: 'PUT',
+        body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+      })
+      showToast('Password changed', { variant: 'success' })
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to change password', { variant: 'error' })
+    } finally {
+      setPasswordSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <SectionHeading label="Profile" />
+        <form onSubmit={handleProfileSave} className={cardClass}>
+          <FieldRow label="Username">
+            <p className="text-sm text-gray-700 dark:text-gray-300">{user?.username}</p>
+          </FieldRow>
+          <FieldRow label="Display name" htmlFor="display-name">
+            <input
+              id="display-name"
+              type="text"
+              value={displayName}
+              onChange={e => setDisplayName(e.target.value)}
+              autoComplete="name"
+              className={inputClass}
+            />
+          </FieldRow>
+          <FieldRow label="Email" htmlFor="email">
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              autoComplete="email"
+              className={inputClass}
+            />
+          </FieldRow>
+          <div className="px-6 py-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={profileSaving || !displayName.trim() || !email.trim()}
+              className={buttonPrimaryClass}
+            >
+              {profileSaving ? 'Saving…' : 'Save changes'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section>
+        <SectionHeading label="Security" />
+        <form onSubmit={handlePasswordChange} className={cardClass}>
+          <FieldRow label="Current password" htmlFor="current-password">
+            <input
+              id="current-password"
+              type="password"
+              value={currentPassword}
+              onChange={e => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+              className={inputClass}
+            />
+          </FieldRow>
+          <FieldRow label="New password" htmlFor="new-password">
+            <input
+              id="new-password"
+              type="password"
+              value={newPassword}
+              onChange={e => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              className={inputClass}
+            />
+          </FieldRow>
+          <FieldRow label="Confirm new password" htmlFor="confirm-password">
+            <input
+              id="confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={e => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              className={inputClass}
+            />
+          </FieldRow>
+          <div className="px-6 py-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={passwordSaving || !currentPassword || !newPassword || !confirmPassword}
+              className={buttonPrimaryClass}
+            >
+              {passwordSaving ? 'Updating…' : 'Change password'}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/profile/ApiTokensTab.tsx
+++ b/src/pages/profile/ApiTokensTab.tsx
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useState, type FormEvent } from 'react'
+import { useAuth } from '../../auth/AuthContext'
+import { useToast } from '../../components/Toast'
+import { SectionHeading, buttonPrimaryClass, buttonSecondaryClass, cardClass, inputClass } from './shared'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface APIToken {
+  id: string
+  name: string
+  token_suffix: string
+  scopes: string[]
+  last_used_at?: string | null
+  expires_at?: string | null
+  revoked_at?: string | null
+  created_at: string
+}
+
+interface CreateTokenResponse extends APIToken {
+  token: string
+}
+
+// Scope presets. Server accepts any scope list; these are UI shortcuts.
+// "Full access" maps to an empty array (server treats empty as "inherit
+// user's full permissions" — classic PAT behaviour).
+const READ_SCOPES = [
+  'books:read', 'library:read', 'loans:read', 'members:read',
+  'series:read', 'shelves:read', 'tags:read',
+] as const
+
+const LIBRARY_SCOPES = [
+  ...READ_SCOPES,
+  'books:create', 'books:update', 'books:delete',
+  'loans:create', 'loans:update', 'loans:delete',
+  'series:create', 'series:update', 'series:delete',
+  'shelves:create', 'shelves:update', 'shelves:delete',
+  'tags:create', 'tags:update', 'tags:delete',
+  'members:create', 'members:update', 'members:delete',
+] as const
+
+type Preset = 'read' | 'library' | 'full'
+
+const PRESET_LABELS: Record<Preset, { title: string; body: string }> = {
+  read: {
+    title: 'Read-only',
+    body: 'Can list and view everything you can, but cannot make any changes.',
+  },
+  library: {
+    title: 'Library access',
+    body: 'Everything read-only can do, plus adding, editing, and removing books, shelves, tags, loans, and series.',
+  },
+  full: {
+    title: 'Full access',
+    body: 'Same permissions as your user account, including admin operations if you are an instance admin.',
+  },
+}
+
+function scopesFor(preset: Preset): string[] {
+  switch (preset) {
+    case 'read':    return [...READ_SCOPES]
+    case 'library': return [...LIBRARY_SCOPES]
+    case 'full':    return []
+  }
+}
+
+// ─── Tab ─────────────────────────────────────────────────────────────────────
+
+export default function ApiTokensTab() {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+
+  const [tokens, setTokens] = useState<APIToken[] | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [justCreated, setJustCreated] = useState<CreateTokenResponse | null>(null)
+
+  const load = async () => {
+    try {
+      const rows = await callApi<APIToken[]>('/api/v1/me/api-tokens')
+      setTokens(rows ?? [])
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to load tokens', { variant: 'error' })
+    }
+  }
+
+  useEffect(() => {
+    void load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleRevoke = async (id: string) => {
+    if (!confirm('Revoke this token? Any client using it will stop working immediately.')) return
+    try {
+      await callApi(`/api/v1/me/api-tokens/${id}`, { method: 'DELETE' })
+      showToast('Token revoked', { variant: 'success' })
+      await load()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to revoke token', { variant: 'error' })
+    }
+  }
+
+  const active = (tokens ?? []).filter(t => !t.revoked_at)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <SectionHeading label="API tokens" />
+          <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+            Personal access tokens for scripts, CI, and the Librarium MCP server.
+            The raw value is shown only when created, so copy it somewhere safe.
+          </p>
+        </div>
+        <button
+          type="button"
+          className={buttonPrimaryClass}
+          onClick={() => setShowCreate(true)}
+        >
+          New token
+        </button>
+      </div>
+
+      <div className={cardClass}>
+        {tokens === null ? (
+          <div className="px-6 py-8 text-sm text-gray-500 dark:text-gray-400 text-center">Loading…</div>
+        ) : active.length === 0 ? (
+          <div className="px-6 py-8 text-sm text-gray-500 dark:text-gray-400 text-center">
+            No active tokens. Create one above to get started.
+          </div>
+        ) : (
+          active.map(t => <TokenRow key={t.id} token={t} onRevoke={handleRevoke} />)
+        )}
+      </div>
+
+      {showCreate && (
+        <CreateTokenModal
+          onClose={() => setShowCreate(false)}
+          onCreated={(tok) => {
+            setJustCreated(tok)
+            setShowCreate(false)
+            void load()
+          }}
+        />
+      )}
+
+      {justCreated && (
+        <NewTokenModal
+          token={justCreated}
+          onClose={() => setJustCreated(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─── Row ─────────────────────────────────────────────────────────────────────
+
+function TokenRow({ token, onRevoke }: { token: APIToken; onRevoke: (id: string) => void }) {
+  const masked = `lbrm_pat_${'•'.repeat(12)}${token.token_suffix}`
+  const scopeLabel =
+    token.scopes.length === 0
+      ? 'Full access'
+      : token.scopes.some(s => s.includes(':create') || s.includes(':update') || s.includes(':delete'))
+        ? 'Library access'
+        : 'Read-only'
+
+  return (
+    <div className="px-6 py-4 flex items-start gap-4">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">{token.name}</p>
+          <span className="rounded bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs text-gray-600 dark:text-gray-400">
+            {scopeLabel}
+          </span>
+        </div>
+        <p className="mt-1 font-mono text-xs text-gray-500 dark:text-gray-400 truncate">{masked}</p>
+        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+          Created {formatDate(token.created_at)}
+          {token.last_used_at
+            ? ` · last used ${formatDate(token.last_used_at)}`
+            : ' · never used'}
+          {token.expires_at ? ` · expires ${formatDate(token.expires_at)}` : ''}
+        </p>
+      </div>
+      <button
+        type="button"
+        className="text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 transition-colors"
+        onClick={() => onRevoke(token.id)}
+      >
+        Revoke
+      </button>
+    </div>
+  )
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString()
+  } catch {
+    return iso
+  }
+}
+
+// ─── Create modal ────────────────────────────────────────────────────────────
+
+function CreateTokenModal({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void
+  onCreated: (t: CreateTokenResponse) => void
+}) {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const [name, setName] = useState('')
+  const [preset, setPreset] = useState<Preset>('library')
+  const [expiry, setExpiry] = useState<'never' | '30' | '90' | '365'>('never')
+  const [saving, setSaving] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) return
+    setSaving(true)
+    try {
+      const expiresAt =
+        expiry === 'never'
+          ? null
+          : new Date(Date.now() + Number(expiry) * 24 * 60 * 60 * 1000).toISOString()
+      const created = await callApi<CreateTokenResponse>('/api/v1/me/api-tokens', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: trimmed,
+          scopes: scopesFor(preset),
+          expires_at: expiresAt,
+        }),
+      })
+      onCreated(created)
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to create token', { variant: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Modal onClose={onClose} title="New API token">
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1" htmlFor="token-name">
+            Name
+          </label>
+          <input
+            id="token-name"
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="e.g. MCP on laptop"
+            maxLength={64}
+            required
+            autoFocus
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+            Scope
+          </label>
+          <div className="space-y-2">
+            {(['read', 'library', 'full'] as const).map(p => (
+              <label
+                key={p}
+                className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer transition-colors ${
+                  preset === p
+                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-950/30'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="scope-preset"
+                  value={p}
+                  checked={preset === p}
+                  onChange={() => setPreset(p)}
+                  className="mt-0.5 accent-blue-600"
+                />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">{PRESET_LABELS[p].title}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{PRESET_LABELS[p].body}</p>
+                </div>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1" htmlFor="token-expiry">
+            Expiration
+          </label>
+          <select
+            id="token-expiry"
+            value={expiry}
+            onChange={e => setExpiry(e.target.value as typeof expiry)}
+            className={inputClass}
+          >
+            <option value="never">Never</option>
+            <option value="30">30 days</option>
+            <option value="90">90 days</option>
+            <option value="365">1 year</option>
+          </select>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <button type="button" onClick={onClose} className={buttonSecondaryClass} disabled={saving}>
+            Cancel
+          </button>
+          <button type="submit" className={buttonPrimaryClass} disabled={saving || !name.trim()}>
+            {saving ? 'Creating…' : 'Create token'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}
+
+// ─── Show-once modal ─────────────────────────────────────────────────────────
+
+function NewTokenModal({ token, onClose }: { token: CreateTokenResponse; onClose: () => void }) {
+  const { show: showToast } = useToast()
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(token.token)
+      setCopied(true)
+      showToast('Copied to clipboard', { variant: 'success' })
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      showToast('Copy failed. Select the text and copy manually.', { variant: 'error' })
+    }
+  }
+
+  return (
+    <Modal title="Your new token" onClose={onClose} dismissOnBackdrop={false}>
+      <div className="space-y-4">
+        <div className="rounded-lg border border-amber-400/60 bg-amber-50 dark:bg-amber-950/30 p-3">
+          <p className="text-sm font-medium text-amber-900 dark:text-amber-200">Copy this now</p>
+          <p className="text-xs text-amber-800 dark:text-amber-300 mt-0.5">
+            This is the only time the raw value will be shown. Once you close this dialog it cannot
+            be recovered. If you lose it, revoke and create a new one.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950 p-3">
+          <p className="font-mono text-xs text-gray-900 dark:text-gray-100 break-all select-all">
+            {token.token}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-3">
+          <button type="button" onClick={handleCopy} className={buttonSecondaryClass}>
+            {copied ? 'Copied ✓' : 'Copy'}
+          </button>
+          <button type="button" onClick={onClose} className={buttonPrimaryClass}>
+            I've saved it
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+// ─── Shared modal chrome ─────────────────────────────────────────────────────
+
+function Modal({
+  title,
+  children,
+  onClose,
+  dismissOnBackdrop = true,
+}: {
+  title: string
+  children: React.ReactNode
+  onClose: () => void
+  dismissOnBackdrop?: boolean
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
+      onClick={dismissOnBackdrop ? onClose : undefined}
+    >
+      <div
+        className="w-full max-w-md rounded-xl bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 shadow-xl"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-800">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{title}</h3>
+        </div>
+        <div className="p-5">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/profile/PreferencesTab.tsx
+++ b/src/pages/profile/PreferencesTab.tsx
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAuth } from '../../auth/AuthContext'
+import { useToast } from '../../components/Toast'
+import { LOCALE_FLAGS, LOCALE_LABELS, LOCALE_STORAGE_KEY, SUPPORTED_LOCALES, type SupportedLocale } from '../../i18n'
+import { SectionHeading, cardClass } from './shared'
+
+// PreferencesTab hosts language + display preferences — the settings that
+// don't involve identity or AI. Stays intentionally small; this is where new
+// "how the app looks or behaves" toggles will land.
+export default function PreferencesTab() {
+  const { callApi } = useAuth()
+  const { show: showToast } = useToast()
+  const { i18n } = useTranslation()
+
+  const currentLocale: SupportedLocale = (SUPPORTED_LOCALES as readonly string[]).includes(i18n.resolvedLanguage ?? '')
+    ? (i18n.resolvedLanguage as SupportedLocale)
+    : 'en-CA'
+
+  const handleLocaleChange = async (locale: SupportedLocale) => {
+    await i18n.changeLanguage(locale)
+    localStorage.setItem(LOCALE_STORAGE_KEY, locale)
+  }
+
+  const [showReadBadges, setShowReadBadges] = useState(true)
+  const [prefsLoading, setPrefsLoading] = useState(true)
+
+  useEffect(() => {
+    callApi<{ prefs: Record<string, unknown> }>('/api/v1/auth/me/preferences')
+      .then(({ prefs }) => {
+        const rb = prefs['show_read_badges']
+        if (typeof rb === 'boolean') setShowReadBadges(rb)
+      })
+      .catch(() => {})
+      .finally(() => setPrefsLoading(false))
+  }, [callApi])
+
+  const handleToggle = async (key: string, value: boolean) => {
+    if (key === 'show_read_badges') setShowReadBadges(value)
+    localStorage.setItem(`librarium:${key}`, String(value))
+    try {
+      await callApi('/api/v1/auth/me/preferences', {
+        method: 'PATCH',
+        body: JSON.stringify({ [key]: value }),
+      })
+    } catch {
+      showToast('Failed to save preference', { variant: 'error' })
+      if (key === 'show_read_badges') setShowReadBadges(!value)
+    }
+  }
+
+  return (
+    <div className="space-y-10">
+      <section>
+        <SectionHeading label="Language" />
+        <div className={cardClass}>
+          <div className="flex items-center justify-between px-6 py-4 gap-6">
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">Interface language</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Switches the language used throughout the web interface.
+              </p>
+            </div>
+            <select
+              value={currentLocale}
+              onChange={e => handleLocaleChange(e.target.value as SupportedLocale)}
+              className="flex-shrink-0 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {SUPPORTED_LOCALES.map(locale => (
+                <option key={locale} value={locale}>
+                  {LOCALE_FLAGS[locale]}  {LOCALE_LABELS[locale]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <SectionHeading label="Display" />
+        <div className={cardClass}>
+          <div className="flex items-center justify-between px-6 py-4">
+            <div className="min-w-0 mr-6">
+              <p className="text-sm font-medium text-gray-900 dark:text-white">Show read status badges</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Show a coloured corner badge on book covers indicating your read status
+                (read, reading, did not finish)
+              </p>
+            </div>
+            {prefsLoading ? (
+              <div className="h-6 w-11 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse flex-shrink-0" />
+            ) : (
+              <button
+                type="button"
+                onClick={() => handleToggle('show_read_badges', !showReadBadges)}
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+                  showReadBadges ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'
+                }`}
+                role="switch"
+                aria-checked={showReadBadges}
+                aria-label="Show read status badges"
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform ${
+                    showReadBadges ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/profile/shared.tsx
+++ b/src/pages/profile/shared.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 fireball1725
+
+// Shared styling constants for the profile-page tabs. Kept in one file so
+// individual tab components stay focused on their own behaviour.
+
+export const inputClass =
+  'w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-1.5 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60'
+
+export const cardClass =
+  'rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-800'
+
+export const buttonPrimaryClass =
+  'px-4 py-1.5 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors'
+
+export const buttonSecondaryClass =
+  'px-4 py-1.5 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 transition-colors'
+
+export function SectionHeading({ label }: { label: string }) {
+  return (
+    <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-3">
+      {label}
+    </h2>
+  )
+}
+
+export function FieldRow({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string
+  htmlFor?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="px-6 py-4">
+      <label
+        className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1"
+        htmlFor={htmlFor}
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
- Profile page splits into tabs (Account / Preferences / AI / API tokens); existing sections reorganised under their natural home, new API tokens tab consumes `/me/api-tokens` with a preset-based create modal and a show-once raw-token reveal.
- Paired with `librarium-api#15`. Plan: `plans/api-tokens.md`.