### PR TITLE
fix(issue-template): bug report missing from picker due to unquoted colons

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: web_version
     attributes:
       label: Web version
-      description: Shown in the page footer (e.g. `Web: v26.4.2`)
+      description: "Shown in the page footer (e.g. `Web: v26.4.2`)"
       placeholder: "e.g. 26.4.2"
     validations:
       required: true
@@ -22,7 +22,7 @@ body:
     id: api_version
     attributes:
       label: API version
-      description: Shown in the page footer (e.g. `API: v26.4.2`)
+      description: "Shown in the page footer (e.g. `API: v26.4.2`)"
       placeholder: "e.g. 26.4.2"
     validations:
       required: true


### PR DESCRIPTION
- Quoted the version-footer descriptions in `bug_report.yml`; unquoted `Web: v26.4.2` / `API: v26.4.2` made the YAML invalid and GitHub silently dropped the template from the new-issue picker.
- No content changes; the bug option will reappear once merged.