### PR TITLE
feat: AI metadata enrichment — review proposals, jobs history filters, AI cleanup toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
       "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.0"
       }
@@ -63,6 +64,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.2.tgz",
       "integrity": "sha512-2Hy8BnCEH31xPeSLbhhB2ctCPXE2ZnASdi+KbSeS79BNbUhL9hAEe20SkUk+BR8aKTmqb6+FKFruk7w8z0VoRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -82,6 +84,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.2.tgz",
       "integrity": "sha512-5fTHQ158jJJ5dC/ECeyIdZUzKxE/mpEMRZxthyG1sw/AKRHKgJBg00Yi6ACVXgycdje7KahRNvNET/uBccwCnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/cssinjs": "^2.1.2",
         "@babel/runtime": "^7.23.2",
@@ -97,6 +100,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
       "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.x"
       }
@@ -106,6 +110,7 @@
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.1.tgz",
       "integrity": "sha512-AMT4N2y++TZETNHiM77fs4a0uPVCJGuL5MTonk13Pvv7UN7sID1cNEZOc1qNqx6zLKAOilTEFAdAoAFKa0U//Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/colors": "^8.0.0",
         "@ant-design/icons-svg": "^4.4.0",
@@ -124,13 +129,15 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
       "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ant-design/react-slick": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
       "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "clsx": "^2.1.1",
@@ -224,7 +231,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -544,7 +550,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -593,7 +598,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -605,7 +609,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -618,7 +621,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -638,13 +640,15 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -978,6 +982,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
       "integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.4"
       },
@@ -990,6 +995,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
       "integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -1006,6 +1012,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
       "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1020,6 +1027,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
       "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/motion": "^1.1.4",
@@ -1036,6 +1044,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.1.tgz",
       "integrity": "sha512-OHaCHLHszCegdXmIq2ZRIZBN/EtpT6Wm8SG/gpzLATHbVKc/avvuKi+zlOuk05FTWvgaMmpxAko44uRJ3M+2pg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ant-design/fast-color": "^3.0.1",
         "@rc-component/util": "^1.3.0",
@@ -1051,6 +1060,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
       "integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0"
       },
@@ -1064,6 +1074,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
       "integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.3",
         "@rc-component/portal": "^2.1.0",
@@ -1080,6 +1091,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
       "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.1.3",
@@ -1096,6 +1108,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
       "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.0.0",
         "@rc-component/util": "^1.2.1",
@@ -1111,6 +1124,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.8.1.tgz",
       "integrity": "sha512-8O7TB55Fi2mWIGvSnwZjk8jFqVNYyKDAswglwGShcbndxqzKz4cHwNtNaLjZlAeRge9wcB0LL8IWsC/Bl18raQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/async-validator": "^5.1.0",
         "@rc-component/util": "^1.6.2",
@@ -1129,6 +1143,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.9.0.tgz",
       "integrity": "sha512-khF7w7xkBH5B1bsBcI1FSUZdkyd1aqpl2eYyILCqCzzQH3XdfehGUaZTnptyaJJfs09/R5hv9jXWyazOMFIClQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/portal": "^2.1.2",
@@ -1145,6 +1160,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
       "integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.4.0",
         "clsx": "^2.1.1"
@@ -1159,6 +1175,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
       "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/mini-decimal": "^1.0.1",
         "@rc-component/util": "^1.4.0",
@@ -1174,6 +1191,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
       "integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/menu": "~1.2.0",
@@ -1192,6 +1210,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
       "integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/overflow": "^1.0.0",
@@ -1209,6 +1228,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.3.tgz",
       "integrity": "sha512-bk/FJ09fLf+NLODMAFll6CfYrHPBioTedhW6lxDBuuWucJEqFUd4l/D/5JgIi3dina6sYahB8iuPAZTNz2pMxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0"
       },
@@ -1221,6 +1241,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.3.2.tgz",
       "integrity": "sha512-itfd+GztzJYAb04Z4RkEub1TbJAfZc2Iuy8p44U44xD1F5+fNYFKI3897ijlbIyfvXkTmMm+KGcjkQQGMHywEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0",
         "clsx": "^2.1.1"
@@ -1235,6 +1256,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
       "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -1251,6 +1273,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
       "integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/util": "^1.2.1",
@@ -1269,6 +1292,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.1.tgz",
       "integrity": "sha512-syfmgAABaHCnCDzPwHZ/2tuvIcpOO3jefYZMmfkN+pmo8HKTzsfhS57vxo4ksPdN0By+uWVJhJWNFozNBxi2eA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/resize-observer": "^1.0.1",
@@ -1285,6 +1309,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
       "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1299,6 +1324,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.1.tgz",
       "integrity": "sha512-9FBYYsvH3HMLICaPDA/1Th5FLaDkFa7qAtangIdlhKb3ZALaR745e9PsOhheJb6asS4QXc12ffiAcjdkZ4C5/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -1337,6 +1363,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
       "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -1354,6 +1381,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
       "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -1368,6 +1396,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/qrcode/-/qrcode-1.1.1.tgz",
       "integrity": "sha512-LfLGNymzKdUPjXUbRP+xOhIWY4jQ+YMj5MmWAcgcAq1Ij8XP7tRmAXqyuv96XvLUBE/5cA8hLFl9eO1JQMujrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.24.7"
       },
@@ -1384,6 +1413,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
       "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1401,6 +1431,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.2.tgz",
       "integrity": "sha512-t/Bb0W8uvL4PYKAB3YcChC+DlHh0Wt5kM7q/J+0qpVEUMLe7Hk5zuvc9km0hMnTFPSx5Z7Wu/fzCLN6erVLE8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.0"
       },
@@ -1414,6 +1445,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
       "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@rc-component/motion": "^1.1.4",
@@ -1430,6 +1462,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.15.tgz",
       "integrity": "sha512-SyVCWnqxCQZZcQvQJ/CxSjx2bGma6ds/HtnpkIfZVnt6RoEgbqUmHgD6vrzNarNXwbLXerwVzWwq8F3d1sst7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/overflow": "^1.0.0",
         "@rc-component/trigger": "^3.0.0",
@@ -1450,6 +1483,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
       "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1467,6 +1501,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
       "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.2.1",
         "clsx": "^2.1.1"
@@ -1484,6 +1519,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
       "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1498,6 +1534,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
       "integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/context": "^2.0.1",
         "@rc-component/resize-observer": "^1.0.0",
@@ -1518,6 +1555,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
       "integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/dropdown": "~1.0.0",
         "@rc-component/menu": "~1.2.0",
@@ -1539,6 +1577,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
       "integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/input": "~1.1.0",
         "@rc-component/resize-observer": "^1.0.0",
@@ -1555,6 +1594,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
       "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/trigger": "^3.7.1",
         "@rc-component/util": "^1.3.0",
@@ -1570,6 +1610,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
       "integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/portal": "^2.2.0",
         "@rc-component/trigger": "^3.0.0",
@@ -1589,6 +1630,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.4.tgz",
       "integrity": "sha512-5Gli43+m4R7NhpYYz3Z61I6LOw9yI6CNChxgVtvrO6xB1qML7iE6QMLVMB3+FTjo2yF6uFdAHtqWPECz/zbX5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.0.0",
         "@rc-component/util": "^1.8.1",
@@ -1608,6 +1650,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
       "integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/select": "~1.6.0",
         "@rc-component/tree": "~1.2.0",
@@ -1624,6 +1667,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
       "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/motion": "^1.1.4",
         "@rc-component/portal": "^2.2.0",
@@ -1644,6 +1688,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
       "integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
@@ -1658,6 +1703,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.10.1.tgz",
       "integrity": "sha512-q++9S6rUa5Idb/xIBNz6jtvumw5+O5YV5V0g4iK9mn9jWs4oGJheE3ZN1kAnE723AXyaD8v95yeOASmdk8Jnng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-mobile": "^5.0.0",
         "react-is": "^18.2.0"
@@ -1672,6 +1718,7 @@
       "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
       "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@rc-component/resize-observer": "^1.0.1",
@@ -2399,7 +2446,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2439,7 +2487,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2450,7 +2497,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2461,7 +2507,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2511,7 +2556,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -2892,7 +2936,6 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -2930,7 +2973,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2971,6 +3013,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3144,7 +3187,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3222,6 +3264,7 @@
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3250,7 +3293,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3408,7 +3452,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
@@ -3495,7 +3540,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3923,7 +3967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -4025,7 +4068,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
       "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -4161,6 +4205,7 @@
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-convert": "^0.2.0"
       }
@@ -4502,6 +4547,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4765,7 +4811,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4818,6 +4863,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4833,6 +4879,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4845,7 +4892,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4862,7 +4910,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4872,7 +4919,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4911,7 +4957,8 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-js-cron": {
       "version": "6.0.2",
@@ -5064,6 +5111,7 @@
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
       "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -5157,7 +5205,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
       "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -5189,7 +5238,8 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -5237,6 +5287,7 @@
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.2.tgz",
       "integrity": "sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       }
@@ -5381,7 +5432,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5487,7 +5537,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5566,7 +5615,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -5794,7 +5842,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/pages/import/ImportPage.tsx
+++ b/src/pages/import/ImportPage.tsx
@@ -365,6 +365,7 @@ export default function ImportPage() {
   const [duplicateUpdateFromCSV, setDuplicateUpdateFromCSV] = useState(false)
   const [enrichMetadata, setEnrichMetadata] = useState(false)
   const [enrichCovers, setEnrichCovers] = useState(false)
+  const [useAICleanup, setUseAICleanup] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -473,6 +474,7 @@ export default function ImportPage() {
       formData.append('default_format', defaultFormat)
       formData.append('enrich_metadata', enrichMetadata ? 'true' : 'false')
       formData.append('enrich_covers', enrichCovers ? 'true' : 'false')
+      formData.append('use_ai_cleanup', useAICleanup ? 'true' : 'false')
       // Only send attribution when the admin has actually retargeted —
       // omitting the field tells the API to use the caller (default).
       if (attributeToUserId && attributeToUserId !== user?.id) {
@@ -877,6 +879,16 @@ export default function ImportPage() {
                     <label className="relative inline-flex items-center cursor-pointer">
                       <input type="checkbox" checked={enrichCovers} onChange={e => setEnrichCovers(e.target.checked)} className="sr-only peer" />
                       <div className="w-9 h-5 bg-gray-200 dark:bg-gray-700 rounded-full peer peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4" />
+                    </label>
+                  </div>
+                  <div className="flex items-center justify-between px-4 py-3.5">
+                    <div>
+                      <p className="text-sm font-medium text-gray-800 dark:text-gray-200">Clean descriptions with AI</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">After enrichment, ask the configured AI to strip marketing fluff and retailer boilerplate from descriptions. Costs AI tokens per book; disabled if no AI provider is configured.</p>
+                    </div>
+                    <label className="relative inline-flex items-center cursor-pointer">
+                      <input type="checkbox" checked={useAICleanup} onChange={e => setUseAICleanup(e.target.checked)} disabled={!enrichMetadata} className="sr-only peer" />
+                      <div className="w-9 h-5 bg-gray-200 dark:bg-gray-700 rounded-full peer peer-checked:bg-blue-600 peer-disabled:opacity-50 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4" />
                     </label>
                   </div>
                 </div>

--- a/src/pages/jobs/JobsHistoryPage.tsx
+++ b/src/pages/jobs/JobsHistoryPage.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 fireball1725
 
-import { useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import PageHeader from '../../components/PageHeader'
@@ -10,7 +10,7 @@ import { usePageTitle } from '../../hooks/usePageTitle'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type JobType = 'import' | 'metadata' | 'cover' | 'cover_backfill' | 'ai_suggestions'
+type JobType = 'import' | 'metadata' | 'cover' | 'cover_backfill' | 'ai_suggestions' | 'ai_metadata_proposal'
 type JobStatus = 'pending' | 'processing' | 'done' | 'failed' | 'cancelled'
 
 interface ImportItem {
@@ -116,11 +116,12 @@ function unifiedToJob(u: UnifiedJobRow): Job {
   // collapse and confused the user when they enabled cover-only.
   let jobType: JobType
   switch (u.kind) {
-    case 'import':         jobType = 'import'; break
-    case 'enrichment':     jobType = u.subtype === 'cover' ? 'cover' : 'metadata'; break
-    case 'ai_suggestions': jobType = 'ai_suggestions'; break
-    case 'cover_backfill': jobType = 'cover_backfill'; break
-    default:               jobType = 'metadata'; break
+    case 'import':                jobType = 'import'; break
+    case 'enrichment':            jobType = u.subtype === 'cover' ? 'cover' : 'metadata'; break
+    case 'ai_suggestions':        jobType = 'ai_suggestions'; break
+    case 'cover_backfill':        jobType = 'cover_backfill'; break
+    case 'ai_metadata_proposal':  jobType = 'ai_metadata_proposal'; break
+    default:                      jobType = 'metadata'; break
   }
 
   return {
@@ -152,11 +153,12 @@ function unifiedToJob(u: UnifiedJobRow): Job {
 
 function TypeBadge({ type }: { type: JobType }) {
   const cfg: Record<JobType, { label: string; cls: string }> = {
-    import:         { label: 'Import',         cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
-    metadata:       { label: 'Metadata',       cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
-    cover:          { label: 'Covers',         cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
-    cover_backfill: { label: 'Cover backfill', cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
-    ai_suggestions: { label: 'Suggestions',    cls: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' },
+    import:               { label: 'Import',         cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
+    metadata:             { label: 'Metadata',       cls: 'bg-sky-100 dark:bg-sky-900/40 text-sky-700 dark:text-sky-300' },
+    cover:                { label: 'Covers',         cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
+    cover_backfill:       { label: 'Cover backfill', cls: 'bg-teal-100 dark:bg-teal-900/40 text-teal-700 dark:text-teal-300' },
+    ai_suggestions:       { label: 'Suggestions',    cls: 'bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300' },
+    ai_metadata_proposal: { label: 'AI proposal',    cls: 'bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300' },
   }
   const { label, cls } = cfg[type] ?? cfg.import
   return (
@@ -216,6 +218,92 @@ function formatDate(iso: string): string {
 
 // ─── Job row ──────────────────────────────────────────────────────────────────
 
+// AICallsPanel pulls and renders ai_metadata_runs attached to a job. Used for
+// enrichment-batch rows to surface the description-cleanup AI calls so the
+// admin can expand each one and see prompt + response.
+interface AIMetadataRun {
+  id: string
+  kind: string
+  target_type: string
+  target_id: string
+  provider_type: string
+  model_id: string
+  status: string
+  error: string
+  tokens_in: number
+  tokens_out: number
+  estimated_cost_usd: number
+  prompt: string
+  response_text: string
+  started_at: string
+  finished_at: string | null
+}
+
+function AICallsPanel({ jobID }: { jobID: string }) {
+  const { callApi } = useAuth()
+  const [runs, setRuns] = useState<AIMetadataRun[] | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  useEffect(() => {
+    callApi<AIMetadataRun[]>(`/api/v1/jobs/${jobID}/ai-runs`)
+      .then(r => setRuns(r ?? []))
+      .catch(() => setRuns([]))
+  }, [callApi, jobID])
+
+  if (!runs || runs.length === 0) return null
+
+  const totalCost = runs.reduce((s, r) => s + (r.estimated_cost_usd || 0), 0)
+  const totalTokens = runs.reduce((s, r) => s + (r.tokens_in || 0) + (r.tokens_out || 0), 0)
+
+  return (
+    <div className="border-t border-gray-100 dark:border-gray-800 px-5 py-3">
+      <div className="flex items-center gap-3 mb-2">
+        <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 font-semibold">AI calls</span>
+        <span className="text-xs text-gray-400 dark:text-gray-500">{runs.length} · {totalTokens.toLocaleString()} tokens · ${totalCost.toFixed(4)}</span>
+      </div>
+      <div className="divide-y divide-gray-100 dark:divide-gray-800">
+        {runs.map(r => (
+          <div key={r.id}>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); setExpanded(prev => prev === r.id ? null : r.id) }}
+              className="w-full flex items-center gap-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-800 -mx-2 px-2 rounded">
+              <ItemStatusDot status={r.status === 'completed' ? 'done' : r.status === 'failed' ? 'failed' : 'pending'} />
+              <span className="text-gray-700 dark:text-gray-300 font-medium font-mono text-xs">{r.kind}</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500 flex-1 truncate">{r.target_type} {r.target_id.slice(0, 8)}</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">{r.tokens_in + r.tokens_out} tok</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500">${r.estimated_cost_usd.toFixed(4)}</span>
+              <svg className={`w-3.5 h-3.5 text-gray-400 transition-transform ${expanded === r.id ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+            {expanded === r.id && (
+              <div className="pb-3 space-y-2">
+                {r.error && (
+                  <div className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950/30 px-3 py-2 rounded">
+                    {r.error}
+                  </div>
+                )}
+                <details className="text-xs">
+                  <summary className="cursor-pointer text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Prompt ({r.prompt.length} chars)</summary>
+                  <pre className="mt-1 whitespace-pre-wrap font-mono text-[11px] bg-gray-50 dark:bg-gray-900 px-3 py-2 rounded border border-gray-200 dark:border-gray-700 max-h-96 overflow-y-auto">{r.prompt}</pre>
+                </details>
+                <details className="text-xs" open>
+                  <summary className="cursor-pointer text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Response ({r.response_text.length} chars)</summary>
+                  <pre className="mt-1 whitespace-pre-wrap font-mono text-[11px] bg-gray-50 dark:bg-gray-900 px-3 py-2 rounded border border-gray-200 dark:border-gray-700 max-h-96 overflow-y-auto">{r.response_text}</pre>
+                </details>
+                <div className="text-[11px] text-gray-400 dark:text-gray-500 font-mono">
+                  {r.provider_type}/{r.model_id} · started {formatDate(r.started_at)}{r.finished_at ? ` · finished ${formatDate(r.finished_at)}` : ''}
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function JobRow({
   job,
   onCancelled,
@@ -235,10 +323,13 @@ function JobRow({
 
   const isAISuggestions = job.type === 'ai_suggestions'
   const isCoverBackfill = job.type === 'cover_backfill'
+  const isAIMetadata    = job.type === 'ai_metadata_proposal'
   // Cover-backfill parents and AI suggestion rows delete via the unified
   // /admin/jobs/:id route (cascades through the kind-specific legacy
   // tables); enrichment and import jobs still hit their per-kind endpoints.
-  const canCancel   = !isCoverBackfill && (job.status === 'pending' || job.status === 'processing')
+  // AI-metadata-proposal jobs run synchronously and are already finished by
+  // the time their row appears in history; no cancel path needed.
+  const canCancel   = !isCoverBackfill && !isAIMetadata && (job.status === 'pending' || job.status === 'processing')
   const canDelete   = job.status === 'done' || job.status === 'failed' || job.status === 'cancelled'
   const isActive    = job.status === 'pending' || job.status === 'processing'
   const isEnrichment = job.type === 'metadata' || job.type === 'cover'
@@ -267,7 +358,7 @@ function JobRow({
     // AI suggestion runs expand into a RunDetailPanel, which self-fetches.
     // Cover-backfill parents are orchestrators with no items — the expand
     // panel just shows the summary, no fetch required.
-    if (!expanded && !isAISuggestions && !isCoverBackfill) {
+    if (!expanded && !isAISuggestions && !isCoverBackfill && !isAIMetadata) {
       setLoadingItems(true)
       try {
         if (isEnr) {
@@ -328,139 +419,132 @@ function JobRow({
     ? Math.max(0, job.processed_rows - job.failed_rows - job.skipped_rows)
     : null
 
+  // Source column content — library for kinds that have one, otherwise who
+  // triggered it (AI runs are user/admin-triggered without a library).
+  const sourceLabel = (isAISuggestions || isAIMetadata)
+    ? `Triggered by ${job.triggered_by ?? 'scheduler'}${job.user_id ? ` · user ${job.user_id.slice(0, 8)}` : ''}`
+    : (job.library_name ?? job.library_id ?? '—')
+
   return (
-    <div className="bg-white dark:bg-gray-900">
-      <button
+    <Fragment>
+      <tr
         onClick={toggleExpand}
-        className="w-full text-left px-5 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+        className="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors cursor-pointer"
       >
-        <div className="flex items-center gap-4">
-          <svg
-            className={`w-4 h-4 text-gray-400 flex-shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
-            fill="none" stroke="currentColor" viewBox="0 0 24 24"
-          >
+        <td className="pl-4 pr-1 py-3 w-8">
+          <svg className={`w-4 h-4 text-gray-400 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
-
-          <div className="flex-1 min-w-0 grid grid-cols-[auto_auto_1fr_auto_auto] items-center gap-3">
-            <TypeBadge type={job.type} />
-            <StatusBadge status={job.status} />
-
-            <div className="min-w-0">
-              <div className="flex items-center gap-2 mb-0.5">
-                <span className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                  {isAISuggestions
-                    ? `Triggered by ${job.triggered_by ?? 'scheduler'}${job.user_id ? ` · user ${job.user_id.slice(0, 8)}` : ''}`
-                    : (job.library_name ?? job.library_id)}
-                </span>
-                <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
-                  {job.id.slice(0, 8)}
-                </span>
-              </div>
-              {isAISuggestions ? (
-                isActive ? (
-                  <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-                    <span className="inline-block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-                    <span>Running…</span>
-                    {job.provider_type && (
-                      <span className="text-gray-400">{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
-                    )}
-                  </div>
-                ) : (
-                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-500 dark:text-gray-400">
-                    {job.provider_type && (
-                      <span>{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
-                    )}
-                    {(job.tokens_in !== undefined || job.tokens_out !== undefined) && (
-                      <span className="tabular-nums">
-                        {formatTokens(job.tokens_in ?? 0)} in / {formatTokens(job.tokens_out ?? 0)} out
-                      </span>
-                    )}
-                    {job.estimated_cost_usd !== undefined && job.estimated_cost_usd > 0 && (
-                      <span className="tabular-nums">${job.estimated_cost_usd.toFixed(4)}</span>
-                    )}
-                    {formatDurationSec(job.created_at, job.finished_at) && (
-                      <span className="tabular-nums">{formatDurationSec(job.created_at, job.finished_at)}</span>
-                    )}
-                    {job.run_error && (
-                      <span className="text-red-600 dark:text-red-400 truncate max-w-xs" title={job.run_error}>
-                        {job.run_error}
-                      </span>
-                    )}
-                  </div>
-                )
-              ) : isActive ? (
-                // processed/failed/skipped are disjoint buckets in the
-                // API; an import that mostly skips would otherwise sit
-                // at 0% all the way through. The bar shows total rows
-                // the worker has finished with, which is the sum.
-                (() => {
-                  const handled = job.processed_rows + job.failed_rows + job.skipped_rows
-                  const pct = job.total_rows > 0 ? Math.round((handled / job.total_rows) * 100) : 0
-                  return (
-                    <div className="flex items-center gap-2">
-                      <div className="flex-1 h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden max-w-xs">
-                        <div
-                          className="h-full rounded-full bg-blue-500 transition-all duration-500"
-                          style={{ width: `${pct}%` }}
-                        />
-                      </div>
-                      <span className="text-xs text-gray-400 tabular-nums">
-                        {handled}/{job.total_rows}
-                      </span>
-                    </div>
-                  )
-                })()
-              ) : (
-                <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
-                  <span>{job.total_rows} {isEnrichment ? 'books' : 'rows'}</span>
-                  {successRows !== null && successRows > 0 && (
-                    <span className="text-green-600 dark:text-green-400">
-                      {successRows} {isEnrichment ? 'updated' : 'added'}
-                    </span>
-                  )}
-                  {job.skipped_rows > 0 && <span className="text-amber-600 dark:text-amber-400">{job.skipped_rows} skipped</span>}
-                  {job.failed_rows > 0 && <span className="text-red-600 dark:text-red-400">{job.failed_rows} failed</span>}
-                </div>
-              )}
-            </div>
-
-            <span className="text-xs text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
-              {formatDate(job.created_at)}
-            </span>
-
-            <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
-              {canCancel && (
-                <button
-                  onClick={handleCancel}
-                  disabled={cancelling}
-                  className="text-xs text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50 transition-colors px-1 py-0.5 rounded"
-                  title="Cancel job"
-                >
-                  {cancelling ? '…' : 'Cancel'}
-                </button>
-              )}
-              {canDelete && (
-                <button
-                  onClick={handleDelete}
-                  disabled={deleting}
-                  className="text-xs text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-50 transition-colors px-1 py-0.5 rounded"
-                  title="Delete job"
-                >
-                  {deleting ? '…' : 'Delete'}
-                </button>
-              )}
-            </div>
+        </td>
+        <td className="px-3 py-3 whitespace-nowrap"><TypeBadge type={job.type} /></td>
+        <td className="px-3 py-3 whitespace-nowrap"><StatusBadge status={job.status} /></td>
+        <td className="px-3 py-3 min-w-0">
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-gray-900 dark:text-white truncate">{sourceLabel}</span>
+            <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">{job.id.slice(0, 8)}</span>
           </div>
-        </div>
-      </button>
-
+        </td>
+        <td className="px-3 py-3 min-w-0">
+          {(isAISuggestions || isAIMetadata) ? (
+            isActive ? (
+              <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                <span className="inline-block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                <span>Running…</span>
+                {job.provider_type && (
+                  <span className="text-gray-400">{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
+                )}
+              </div>
+            ) : (
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-gray-500 dark:text-gray-400">
+                {job.provider_type && (
+                  <span>{job.provider_type}{job.model_id ? ` (${job.model_id})` : ''}</span>
+                )}
+                {(job.tokens_in !== undefined || job.tokens_out !== undefined) && (
+                  <span className="tabular-nums">
+                    {formatTokens(job.tokens_in ?? 0)} in / {formatTokens(job.tokens_out ?? 0)} out
+                  </span>
+                )}
+                {job.estimated_cost_usd !== undefined && job.estimated_cost_usd > 0 && (
+                  <span className="tabular-nums">${job.estimated_cost_usd.toFixed(4)}</span>
+                )}
+                {formatDurationSec(job.created_at, job.finished_at) && (
+                  <span className="tabular-nums">{formatDurationSec(job.created_at, job.finished_at)}</span>
+                )}
+                {job.run_error && (
+                  <span className="text-red-600 dark:text-red-400 truncate max-w-xs" title={job.run_error}>
+                    {job.run_error}
+                  </span>
+                )}
+              </div>
+            )
+          ) : isActive ? (
+            // processed/failed/skipped are disjoint buckets in the API; the
+            // bar shows total rows the worker has finished with (sum).
+            (() => {
+              const handled = job.processed_rows + job.failed_rows + job.skipped_rows
+              const pct = job.total_rows > 0 ? Math.round((handled / job.total_rows) * 100) : 0
+              return (
+                <div className="flex items-center gap-2">
+                  <div className="flex-1 h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden max-w-xs">
+                    <div className="h-full rounded-full bg-blue-500 transition-all duration-500"
+                      style={{ width: `${pct}%` }} />
+                  </div>
+                  <span className="text-xs text-gray-400 tabular-nums whitespace-nowrap">
+                    {handled}/{job.total_rows}
+                  </span>
+                </div>
+              )
+            })()
+          ) : (
+            <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+              <span>{job.total_rows} {isEnrichment ? 'books' : 'rows'}</span>
+              {successRows !== null && successRows > 0 && (
+                <span className="text-green-600 dark:text-green-400">
+                  {successRows} {isEnrichment ? 'updated' : 'added'}
+                </span>
+              )}
+              {job.skipped_rows > 0 && <span className="text-amber-600 dark:text-amber-400">{job.skipped_rows} skipped</span>}
+              {job.failed_rows > 0 && <span className="text-red-600 dark:text-red-400">{job.failed_rows} failed</span>}
+            </div>
+          )}
+        </td>
+        <td className="px-3 py-3 text-xs text-gray-400 dark:text-gray-500 tabular-nums whitespace-nowrap">
+          {formatDate(job.created_at)}
+        </td>
+        <td className="pl-3 pr-4 py-3" onClick={e => e.stopPropagation()}>
+          <div className="flex items-center gap-3 justify-end">
+            {canCancel && (
+              <button onClick={handleCancel} disabled={cancelling}
+                className="text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 transition-colors"
+                title="Cancel job">
+                {cancelling ? '…' : 'Cancel'}
+              </button>
+            )}
+            {canDelete && (
+              <button onClick={handleDelete} disabled={deleting}
+                className="text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-50 transition-colors"
+                title="Delete job">
+                {deleting ? '…' : 'Delete'}
+              </button>
+            )}
+          </div>
+        </td>
+      </tr>
       {expanded && (
-        <div className="border-t border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
+        <tr className="bg-gray-50 dark:bg-gray-900/50">
+          <td colSpan={7} className="border-b border-gray-100 dark:border-gray-800 p-0">
           {isAISuggestions ? (
             <div className="px-5 py-4">
               <RunDetailPanel
                 endpoint={`/api/v1/admin/jobs/ai-suggestions/runs/${job.id}`}
+                hideSummary
+              />
+            </div>
+          ) : isAIMetadata ? (
+            <div className="px-5 py-4">
+              <RunDetailPanel
+                endpoint={`/api/v1/admin/jobs/ai-metadata/runs/${job.id}`}
                 hideSummary
               />
             </div>
@@ -482,42 +566,45 @@ function JobRow({
               Loading…
             </div>
           ) : isEnrichment ? (
-            enrichItems && enrichItems.length > 0 ? (
-              <div className="divide-y divide-gray-100 dark:divide-gray-800">
-                {enrichItems.map(item => (
-                  <div key={item.id} className="flex items-start gap-3 px-5 py-2.5 text-sm">
-                    <ItemStatusDot status={item.status} />
-                    <div className="flex-1 min-w-0">
-                      <span className="text-gray-800 dark:text-gray-200 font-medium">
-                        {item.book_title || <span className="text-gray-400 italic font-mono text-xs">{item.book_id?.slice(0, 8) ?? 'Unknown'}</span>}
-                      </span>
-                      {item.message && (
-                        <p className={`text-xs mt-0.5 ${
-                          item.status === 'failed' ? 'text-red-600 dark:text-red-400'
-                            : item.status === 'skipped' ? 'text-amber-600 dark:text-amber-400'
-                            : 'text-gray-400 dark:text-gray-500'
-                        }`}>
-                          {item.message}
-                        </p>
+            <>
+              {enrichItems && enrichItems.length > 0 ? (
+                <div className="divide-y divide-gray-100 dark:divide-gray-800">
+                  {enrichItems.map(item => (
+                    <div key={item.id} className="flex items-start gap-3 px-5 py-2.5 text-sm">
+                      <ItemStatusDot status={item.status} />
+                      <div className="flex-1 min-w-0">
+                        <span className="text-gray-800 dark:text-gray-200 font-medium">
+                          {item.book_title || <span className="text-gray-400 italic font-mono text-xs">{item.book_id?.slice(0, 8) ?? 'Unknown'}</span>}
+                        </span>
+                        {item.message && (
+                          <p className={`text-xs mt-0.5 ${
+                            item.status === 'failed' ? 'text-red-600 dark:text-red-400'
+                              : item.status === 'skipped' ? 'text-amber-600 dark:text-amber-400'
+                              : 'text-gray-400 dark:text-gray-500'
+                          }`}>
+                            {item.message}
+                          </p>
+                        )}
+                      </div>
+                      {item.book_id && (
+                        <Link
+                          to={job.library_id
+                            ? `/libraries/${job.library_id}/books/${item.book_id}`
+                            : `/books/${item.book_id}`}
+                          className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex-shrink-0"
+                          onClick={e => e.stopPropagation()}
+                        >
+                          View
+                        </Link>
                       )}
                     </div>
-                    {item.book_id && (
-                      <Link
-                        to={job.library_id
-                          ? `/libraries/${job.library_id}/books/${item.book_id}`
-                          : `/books/${item.book_id}`}
-                        className="text-xs text-blue-600 dark:text-blue-400 hover:underline flex-shrink-0"
-                        onClick={e => e.stopPropagation()}
-                      >
-                        View
-                      </Link>
-                    )}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="px-5 py-4 text-sm text-gray-400 dark:text-gray-500">No items.</p>
-            )
+                  ))}
+                </div>
+              ) : (
+                <p className="px-5 py-4 text-sm text-gray-400 dark:text-gray-500">No items.</p>
+              )}
+              <AICallsPanel jobID={job.id} />
+            </>
           ) : items && items.length > 0 ? (
             <div className="divide-y divide-gray-100 dark:divide-gray-800">
               {items.map(item => (
@@ -556,9 +643,10 @@ function JobRow({
           ) : (
             <p className="px-5 py-4 text-sm text-gray-400 dark:text-gray-500">No items.</p>
           )}
-        </div>
+          </td>
+        </tr>
       )}
-    </div>
+    </Fragment>
   )
 }
 
@@ -567,22 +655,44 @@ function JobRow({
 export default function JobsHistoryPage() {
   const { callApi } = useAuth()
   const [jobs, setJobs] = useState<Job[]>([])
+  const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [clearingAll, setClearingAll] = useState(false)
+  // Filter + pagination state. Each filter value maps to a backend query param;
+  // the special 'metadata' / 'cover' filter values translate to kind=enrichment
+  // + subtype=metadata|cover so the UI can split enrichment into its two
+  // user-meaningful flavours.
+  const [kindFilter, setKindFilter] = useState<string>('')
+  const [statusFilter, setStatusFilter] = useState<string>('')
+  const [page, setPage] = useState(1)
+  const PAGE_SIZE = 50
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const burstTimers = useRef<Array<ReturnType<typeof setTimeout>>>([])
   usePageTitle('Job history')
 
   const loadJobs = async () => {
     try {
-      // One fetch replaces the three-endpoint fanout — the unified
-      // /admin/jobs/history returns every kind in one paginated shape.
+      const params = new URLSearchParams()
+      params.set('limit', String(PAGE_SIZE))
+      params.set('offset', String((page - 1) * PAGE_SIZE))
+      // Map UI kind values to backend kind + subtype.
+      if (kindFilter === 'metadata') {
+        params.set('kind', 'enrichment')
+        params.set('subtype', 'metadata')
+      } else if (kindFilter === 'cover') {
+        params.set('kind', 'enrichment')
+        params.set('subtype', 'cover')
+      } else if (kindFilter !== '') {
+        params.set('kind', kindFilter)
+      }
+      if (statusFilter !== '') params.set('status', statusFilter)
       const resp = await callApi<{ items: UnifiedJobRow[]; total: number }>(
-        '/api/v1/admin/jobs/history?limit=200'
+        `/api/v1/admin/jobs/history?${params.toString()}`
       )
       const merged = (resp?.items ?? []).map(unifiedToJob)
       setJobs(merged)
+      setTotal(resp?.total ?? 0)
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load jobs')
     } finally {
@@ -590,6 +700,7 @@ export default function JobsHistoryPage() {
     }
   }
 
+  // Reload when filters or page change.
   useEffect(() => {
     loadJobs()
     return () => {
@@ -597,7 +708,13 @@ export default function JobsHistoryPage() {
       burstTimers.current = []
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [kindFilter, statusFilter, page])
+
+  // Reset to page 1 when filters change so the user doesn't end up on an
+  // empty page from a previous filter's deeper offsets.
+  useEffect(() => {
+    setPage(1)
+  }, [kindFilter, statusFilter])
 
   // Auto-poll while any job is active
   useEffect(() => {
@@ -663,7 +780,12 @@ export default function JobsHistoryPage() {
           </button>
         ) : undefined}
       />
-      <div className="max-w-4xl px-8 py-8">
+      {/* Wider than the default admin max-w-4xl: the jobs table has 7 columns
+          with badges + summaries + actions; max-w-4xl was clipping the
+          Created column and the action buttons. max-w-7xl gives breathing
+          room while still keeping the line lengths reasonable on huge
+          monitors. */}
+      <div className="max-w-7xl px-8 py-8">
 
       {error && (
         <div className="mb-6 rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400">
@@ -671,24 +793,99 @@ export default function JobsHistoryPage() {
         </div>
       )}
 
+      {/* Filter row */}
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Type</span>
+          <select value={kindFilter} onChange={e => setKindFilter(e.target.value)}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-2 py-1 text-sm">
+            <option value="">All</option>
+            <option value="import">Import</option>
+            <option value="metadata">Metadata</option>
+            <option value="cover">Covers</option>
+            <option value="cover_backfill">Cover backfill</option>
+            <option value="ai_suggestions">AI suggestions</option>
+            <option value="ai_metadata_proposal">AI proposal</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Status</span>
+          <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}
+            className="rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-2 py-1 text-sm">
+            <option value="">All</option>
+            <option value="pending">Pending</option>
+            <option value="running">Running</option>
+            <option value="completed">Done</option>
+            <option value="failed">Failed</option>
+            <option value="cancelled">Cancelled</option>
+          </select>
+        </label>
+        {(kindFilter !== '' || statusFilter !== '') && (
+          <button onClick={() => { setKindFilter(''); setStatusFilter('') }}
+            className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+            Clear filters
+          </button>
+        )}
+        <span className="ml-auto text-xs text-gray-400 dark:text-gray-500">
+          {total === 0 ? 'No matches' : total === 1 ? '1 job' : `${total.toLocaleString()} jobs`}
+        </span>
+      </div>
+
       {jobs.length === 0 ? (
         <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 p-12 text-center">
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">No jobs yet</p>
+          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+            {kindFilter !== '' || statusFilter !== '' ? 'No jobs match these filters' : 'No jobs yet'}
+          </p>
           <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-            Start an import from the Import tool to see background jobs here.
+            {kindFilter !== '' || statusFilter !== ''
+              ? 'Adjust the type or status filter above.'
+              : 'Start an import from the Import tool to see background jobs here.'}
           </p>
         </div>
       ) : (
-        <div className="rounded-xl border border-gray-200 dark:border-gray-700 divide-y divide-gray-100 dark:divide-gray-800 overflow-hidden">
-          {jobs.map(job => (
-            <JobRow
-              key={job.id}
-              job={job}
-              onCancelled={handleCancelled}
-              onDeleted={handleDeleted}
-            />
-          ))}
-        </div>
+        <>
+          <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+                <tr>
+                  {['', 'Type', 'Status', 'Source', 'Summary', 'Created', ''].map((h, i) => (
+                    <th key={i} className="px-3 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 whitespace-nowrap">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {jobs.map(job => (
+                  <JobRow
+                    key={job.id}
+                    job={job}
+                    onCancelled={handleCancelled}
+                    onDeleted={handleDeleted}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination — only renders when there are more jobs than fit in
+              one page. Server enforces newest-first ordering. */}
+          {total > PAGE_SIZE && (
+            <div className="flex items-center justify-between mt-4 text-sm">
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Page {page} of {Math.max(1, Math.ceil(total / PAGE_SIZE))} · showing {(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, total)} of {total.toLocaleString()}
+              </span>
+              <div className="flex items-center gap-2">
+                <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
+                  className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                  ← Newer
+                </button>
+                <button onClick={() => setPage(p => p + 1)} disabled={page * PAGE_SIZE >= total}
+                  className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                  Older →
+                </button>
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
     </>

--- a/src/pages/libraries/LibraryPage.tsx
+++ b/src/pages/libraries/LibraryPage.tsx
@@ -5149,7 +5149,7 @@ function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: Serie
       }
     }
     collected.sort((a, b) => a.sortKey - b.sortKey)
-    groups = collected.map(({ sortKey: _sortKey, ...g }) => g)
+    groups = collected.map(({ key, label, arcId, rows }) => ({ key, label, arcId, rows }))
   } else {
     // Flat — single group with entries + ghosts interleaved by position.
     const allRows: Row[] = [...entries.map(e => ({ type: 'entry' as const, entry: e }))]

--- a/src/pages/libraries/LibraryPage.tsx
+++ b/src/pages/libraries/LibraryPage.tsx
@@ -2,7 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { useParams, Link, useOutletContext, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth, ApiError } from '../../auth/AuthContext'
 import type { Crumb, LibraryOutletContext } from '../../components/LibraryOutlet'
-import type { LibraryMember, Book, PagedBooks, MediaType, ContributorResult, Tag, Shelf, Loan, Series, SeriesArc, SeriesEntry, SeriesPreviewBook, SeriesVolume, SeriesMatchCandidate, SeriesSuggestion, ISBNLookupResult, SeriesLookupResult, Genre } from '../../types'
+import type { LibraryMember, Book, PagedBooks, MediaType, ContributorResult, Tag, Shelf, Loan, Series, SeriesArc, SeriesEntry, SeriesPreviewBook, SeriesVolume, SeriesMatchCandidate, SeriesSuggestion, ISBNLookupResult, SeriesLookupResult, Genre, AIMetadataProposal, SeriesMetadataPayload, SeriesArcsPayload } from '../../types'
 import { useAuthenticatedImage } from '../../hooks/useAuthenticatedImage'
 import { LANGUAGE_OPTIONS } from '../../components/AddEditionModal'
 import BookCover, { BookCoverThumb } from '../../components/BookCover'
@@ -1853,6 +1853,7 @@ function BooksTab({ libraryId, mediaTypes, canEdit }: BooksTabProps) {
   // Bulk metadata / cover refresh
   const [showBulkMetaModal, setShowBulkMetaModal] = useState(false)
   const [bulkMetaForce, setBulkMetaForce] = useState(false)
+  const [bulkMetaUseAI, setBulkMetaUseAI] = useState(false)
   const [isBulkJobEnqueueing, setIsBulkJobEnqueueing] = useState(false)
 
   const [perPage, setPerPage] = useState(() => {
@@ -2175,13 +2176,13 @@ function BooksTab({ libraryId, mediaTypes, canEdit }: BooksTabProps) {
       genre_ids: (book.genres ?? []).filter(g => g.id !== genreId).map(g => g.id),
     }))
 
-  const bulkEnrichMetadata = async (force: boolean) => {
+  const bulkEnrichMetadata = async (force: boolean, useAICleanup: boolean) => {
     const bookIds = Array.from(selectedIds)
     setIsBulkJobEnqueueing(true)
     try {
       await callApi(`/api/v1/libraries/${libraryId}/books/bulk/enrich`, {
         method: 'POST',
-        body: JSON.stringify({ book_ids: bookIds, force }),
+        body: JSON.stringify({ book_ids: bookIds, force, use_ai_cleanup: useAICleanup }),
       })
       showToast(`Metadata refresh queued for ${bookIds.length} book${bookIds.length !== 1 ? 's' : ''}.`, {
         action: { label: 'View jobs', to: '/admin/settings/jobs' },
@@ -2190,6 +2191,7 @@ function BooksTab({ libraryId, mediaTypes, canEdit }: BooksTabProps) {
     setIsBulkJobEnqueueing(false)
     setShowBulkMetaModal(false)
     setBulkMetaForce(false)
+    setBulkMetaUseAI(false)
     setSelectedIds(new Set())
   }
 
@@ -2569,7 +2571,7 @@ function BooksTab({ libraryId, mediaTypes, canEdit }: BooksTabProps) {
                   Queue metadata enrichment for {selectedIds.size} book{selectedIds.size !== 1 ? 's' : ''}?
                   Books without an ISBN will be skipped.
                 </p>
-                <label className="flex items-start gap-2.5 mb-5 cursor-pointer select-none">
+                <label className="flex items-start gap-2.5 mb-3 cursor-pointer select-none">
                   <input
                     type="checkbox"
                     checked={bulkMetaForce}
@@ -2583,10 +2585,24 @@ function BooksTab({ libraryId, mediaTypes, canEdit }: BooksTabProps) {
                     </span>
                   </span>
                 </label>
+                <label className="flex items-start gap-2.5 mb-5 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={bulkMetaUseAI}
+                    onChange={e => setBulkMetaUseAI(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600"
+                  />
+                  <span className="text-sm text-gray-700 dark:text-gray-300">
+                    Clean descriptions with AI
+                    <span className="block text-xs text-gray-500 dark:text-gray-500 mt-0.5">
+                      Strip marketing fluff and retailer boilerplate from each book's description after enrichment. Uses AI tokens.
+                    </span>
+                  </span>
+                </label>
                 <div className="flex gap-2 justify-end">
                   <button
                     type="button"
-                    onClick={() => { setShowBulkMetaModal(false); setBulkMetaForce(false) }}
+                    onClick={() => { setShowBulkMetaModal(false); setBulkMetaForce(false); setBulkMetaUseAI(false) }}
                     className="rounded-lg px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
                   >
                     Cancel
@@ -2594,7 +2610,7 @@ function BooksTab({ libraryId, mediaTypes, canEdit }: BooksTabProps) {
                   <button
                     type="button"
                     disabled={isBulkJobEnqueueing}
-                    onClick={() => bulkEnrichMetadata(bulkMetaForce)}
+                    onClick={() => bulkEnrichMetadata(bulkMetaForce, bulkMetaUseAI)}
                     className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
                   >
                     {isBulkJobEnqueueing ? 'Queuing…' : 'Queue jobs'}
@@ -4457,6 +4473,179 @@ const COVER_GRADIENTS = [
   'from-teal-500 to-blue-400',
 ]
 
+// ─── AI proposal review panel ────────────────────────────────────────────────
+// Pending AI suggestions render at the top of the series detail view. The user
+// reviews each proposal, accepts a subset of fields/arcs (or all), or rejects.
+// On accept, the API writes the chosen subset to the series and creates arcs.
+
+interface ProposalsPanelProps {
+  proposals: AIMetadataProposal[]
+  existingArcCount: number
+  onAccept: (proposalID: string, body?: Record<string, unknown>) => void
+  onReject: (proposalID: string) => void
+}
+
+function ProposalsPanel({ proposals, existingArcCount, onAccept, onReject }: ProposalsPanelProps) {
+  if (proposals.length === 0) return null
+  return (
+    <div className="mb-4 space-y-3">
+      {proposals.map(p => p.kind === 'series_metadata' ? (
+        <SeriesMetadataProposalCard key={p.id} proposal={p} onAccept={onAccept} onReject={onReject} />
+      ) : (
+        <SeriesArcsProposalCard key={p.id} proposal={p} existingArcCount={existingArcCount} onAccept={onAccept} onReject={onReject} />
+      ))}
+    </div>
+  )
+}
+
+function SeriesMetadataProposalCard({ proposal, onAccept, onReject }: { proposal: AIMetadataProposal; onAccept: (id: string, body?: Record<string, unknown>) => void; onReject: (id: string) => void }) {
+  const payload = proposal.payload as SeriesMetadataPayload
+  const fields: { key: string; label: string; value: string | null }[] = [
+    { key: 'status', label: 'Status', value: payload.status ?? null },
+    { key: 'total_count', label: 'Total volumes', value: payload.total_count != null ? String(payload.total_count) : null },
+    { key: 'demographic', label: 'Demographic', value: payload.demographic ?? null },
+    { key: 'genres', label: 'Genres', value: payload.genres && payload.genres.length > 0 ? payload.genres.join(', ') : null },
+    { key: 'description', label: 'Description', value: payload.description ?? null },
+  ].filter(f => f.value !== null)
+
+  const [selected, setSelected] = useState<Set<string>>(new Set(fields.map(f => f.key)))
+  const toggle = (k: string) => setSelected(prev => { const n = new Set(prev); if (n.has(k)) n.delete(k); else n.add(k); return n })
+
+  const apply = () => {
+    if (selected.size === 0) return
+    const allSelected = selected.size === fields.length
+    onAccept(proposal.id, allSelected ? undefined : { fields: Array.from(selected) })
+  }
+
+  if (fields.length === 0) {
+    return (
+      <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4 text-sm">
+        <div className="flex items-center justify-between">
+          <p className="text-amber-800 dark:text-amber-300">AI didn't have evidence for any series-level fields.</p>
+          <button onClick={() => onReject(proposal.id)} className="text-xs text-amber-700 dark:text-amber-400 hover:underline">Dismiss</button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-purple-200 dark:border-purple-800 bg-purple-50/40 dark:bg-purple-950/30 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <p className="text-sm font-semibold text-purple-900 dark:text-purple-200">AI suggestion: series fields</p>
+          <p className="text-xs text-purple-700/80 dark:text-purple-300/70">Review and pick which fields to apply.</p>
+        </div>
+        <button onClick={() => onReject(proposal.id)} className="text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400">Dismiss</button>
+      </div>
+      <ul className="space-y-1.5 mb-3">
+        {fields.map(f => (
+          <li key={f.key}>
+            <label className="flex items-start gap-2.5 cursor-pointer select-none">
+              <input type="checkbox" checked={selected.has(f.key)} onChange={() => toggle(f.key)}
+                className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600" />
+              <span className="text-sm text-gray-800 dark:text-gray-200 flex-1">
+                <span className="font-medium">{f.label}:</span>{' '}
+                <span className="text-gray-600 dark:text-gray-400">{f.value}</span>
+              </span>
+            </label>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2 justify-end">
+        <button onClick={() => onReject(proposal.id)}
+          className="rounded-md px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800">
+          Reject all
+        </button>
+        <button onClick={apply} disabled={selected.size === 0}
+          className="rounded-md bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-purple-700 disabled:opacity-50">
+          Apply selected
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function SeriesArcsProposalCard({ proposal, existingArcCount, onAccept, onReject }: { proposal: AIMetadataProposal; existingArcCount: number; onAccept: (id: string, body?: Record<string, unknown>) => void; onReject: (id: string) => void }) {
+  const payload = proposal.payload as SeriesArcsPayload
+  const [selected, setSelected] = useState<Set<number>>(new Set(payload.arcs?.map((_, i) => i) ?? []))
+  const [assignBooks, setAssignBooks] = useState(true)
+
+  if (!payload.arcs || payload.arcs.length === 0) {
+    return (
+      <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 p-4 text-sm">
+        <div className="flex items-center justify-between">
+          <p className="text-amber-800 dark:text-amber-300">AI didn't propose any canonical arcs for this series.</p>
+          <button onClick={() => onReject(proposal.id)} className="text-xs text-amber-700 dark:text-amber-400 hover:underline">Dismiss</button>
+        </div>
+      </div>
+    )
+  }
+
+  const toggle = (i: number) => setSelected(prev => { const n = new Set(prev); if (n.has(i)) n.delete(i); else n.add(i); return n })
+
+  const apply = () => {
+    if (selected.size === 0) return
+    if (existingArcCount > 0) {
+      const msg = `This will delete the ${existingArcCount} existing arc${existingArcCount === 1 ? '' : 's'} on this series and replace ${existingArcCount === 1 ? 'it' : 'them'} with ${selected.size} new arc${selected.size === 1 ? '' : 's'}. Books will be re-grouped by the new volume ranges. Continue?`
+      if (!confirm(msg)) return
+    }
+    const all = selected.size === payload.arcs.length
+    const body: Record<string, unknown> = { assign_books: assignBooks }
+    if (!all) body.arc_indices = Array.from(selected).sort((a, b) => a - b)
+    onAccept(proposal.id, body)
+  }
+
+  const isReplace = existingArcCount > 0
+
+  return (
+    <div className="rounded-xl border border-purple-200 dark:border-purple-800 bg-purple-50/40 dark:bg-purple-950/30 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <p className="text-sm font-semibold text-purple-900 dark:text-purple-200">AI suggestion: arcs</p>
+          <p className="text-xs text-purple-700/80 dark:text-purple-300/70">
+            {isReplace
+              ? `Accepting will replace the ${existingArcCount} existing arc${existingArcCount === 1 ? '' : 's'} on this series.`
+              : 'Pick which arcs to create.'}
+          </p>
+        </div>
+        <button onClick={() => onReject(proposal.id)} className="text-xs text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400">Dismiss</button>
+      </div>
+      <ul className="space-y-1.5 mb-3">
+        {payload.arcs.map((arc, i) => {
+          const range = arc.vol_start != null && arc.vol_end != null ? `vols ${arc.vol_start}–${arc.vol_end}` : 'no range'
+          return (
+            <li key={i}>
+              <label className="flex items-start gap-2.5 cursor-pointer select-none">
+                <input type="checkbox" checked={selected.has(i)} onChange={() => toggle(i)}
+                  className="mt-0.5 h-4 w-4 rounded border-gray-300 dark:border-gray-600" />
+                <span className="text-sm text-gray-800 dark:text-gray-200 flex-1">
+                  <span className="font-medium">{arc.name}</span>
+                  <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">{range}</span>
+                </span>
+              </label>
+            </li>
+          )
+        })}
+      </ul>
+      <label className="flex items-center gap-2.5 mb-3 cursor-pointer select-none">
+        <input type="checkbox" checked={assignBooks} onChange={e => setAssignBooks(e.target.checked)}
+          className="h-4 w-4 rounded border-gray-300 dark:border-gray-600" />
+        <span className="text-xs text-gray-700 dark:text-gray-300">Auto-assign books in suggested ranges to their arcs</span>
+      </label>
+      <div className="flex gap-2 justify-end">
+        <button onClick={() => onReject(proposal.id)}
+          className="rounded-md px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800">
+          Reject all
+        </button>
+        <button onClick={apply} disabled={selected.size === 0}
+          className="rounded-md bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-purple-700 disabled:opacity-50">
+          {isReplace ? 'Replace arcs' : 'Create selected arcs'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
 // ─── Arc management ──────────────────────────────────────────────────────────
 
 interface ArcManagerPanelProps {
@@ -4466,9 +4655,11 @@ interface ArcManagerPanelProps {
   open: boolean
   onToggle: () => void
   onChanged: () => void
+  onSuggestArcs?: () => void
+  isSuggesting?: boolean
 }
 
-function ArcManagerPanel({ libraryId, seriesId, arcs, open, onToggle, onChanged }: ArcManagerPanelProps) {
+function ArcManagerPanel({ libraryId, seriesId, arcs, open, onToggle, onChanged, onSuggestArcs, isSuggesting }: ArcManagerPanelProps) {
   const { callApi } = useAuth()
   const [editingArc, setEditingArc] = useState<SeriesArc | null>(null)
   const [showAddForm, setShowAddForm] = useState(false)
@@ -4507,6 +4698,11 @@ function ArcManagerPanel({ libraryId, seriesId, arcs, open, onToggle, onChanged 
                     {formatPosition(arc.position)}
                   </span>
                   <span className="flex-1 font-medium text-gray-900 dark:text-white">{arc.name}</span>
+                  {arc.vol_start != null && arc.vol_end != null && (
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                      vols {formatPosition(arc.vol_start)}–{formatPosition(arc.vol_end)}
+                    </span>
+                  )}
                   <span className="text-xs text-gray-400 dark:text-gray-500">{arc.book_count} book{arc.book_count !== 1 ? 's' : ''}</span>
                   <button onClick={() => setEditingArc(arc)}
                     className="p-1 rounded text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
@@ -4541,8 +4737,16 @@ function ArcManagerPanel({ libraryId, seriesId, arcs, open, onToggle, onChanged 
               onSaved={() => { setShowAddForm(false); onChanged() }}
             />
           ) : (
-            <button onClick={() => setShowAddForm(true)}
-              className="text-sm text-blue-600 dark:text-blue-400 hover:underline">+ Add arc</button>
+            <div className="flex items-center gap-3">
+              <button onClick={() => setShowAddForm(true)}
+                className="text-sm text-blue-600 dark:text-blue-400 hover:underline">+ Add arc</button>
+              {onSuggestArcs && (
+                <button onClick={onSuggestArcs} disabled={isSuggesting}
+                  className="text-sm text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-50">
+                  {isSuggesting ? 'Asking AI…' : (sorted.length > 0 ? 'Re-suggest with AI' : 'Suggest with AI')}
+                </button>
+              )}
+            </div>
           )}
         </div>
       )}
@@ -4564,12 +4768,29 @@ function ArcEditRow({ libraryId, seriesId, arc, defaultPosition, onCancel, onSav
   const [name, setName] = useState(arc?.name ?? '')
   const [position, setPosition] = useState(String(arc?.position ?? defaultPosition ?? 1))
   const [description, setDescription] = useState(arc?.description ?? '')
+  // Vol bounds are optional. Empty input string ⇒ null in the request body
+  // so existing bounds can be cleared. Stored as strings while editing so a
+  // partially-typed number doesn't get coerced to NaN mid-keystroke.
+  const [volStart, setVolStart] = useState(arc?.vol_start != null ? String(arc.vol_start) : '')
+  const [volEnd, setVolEnd] = useState(arc?.vol_end != null ? String(arc.vol_end) : '')
   const [saving, setSaving] = useState(false)
 
   const save = async () => {
     if (!name.trim()) return
     setSaving(true)
-    const body = JSON.stringify({ name: name.trim(), position: Number(position) || 0, description })
+    const parseBound = (s: string): number | null => {
+      const t = s.trim()
+      if (t === '') return null
+      const n = Number(t)
+      return Number.isFinite(n) ? n : null
+    }
+    const body = JSON.stringify({
+      name: name.trim(),
+      position: Number(position) || 0,
+      description,
+      vol_start: parseBound(volStart),
+      vol_end: parseBound(volEnd),
+    })
     const url = arc
       ? `/api/v1/libraries/${libraryId}/series/${seriesId}/arcs/${arc.id}`
       : `/api/v1/libraries/${libraryId}/series/${seriesId}/arcs`
@@ -4594,6 +4815,19 @@ function ArcEditRow({ libraryId, seriesId, arc, defaultPosition, onCancel, onSav
       <input type="text" value={description} onChange={e => setDescription(e.target.value)}
         className="w-full rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white px-2 py-1 text-sm"
         placeholder="Description (optional)" />
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400 w-20">Vol range</span>
+        <input type="number" step="any" value={volStart} onChange={e => setVolStart(e.target.value)}
+          className="w-20 rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white px-2 py-1 text-sm"
+          placeholder="Start" />
+        <span className="text-xs text-gray-400">–</span>
+        <input type="number" step="any" value={volEnd} onChange={e => setVolEnd(e.target.value)}
+          className="w-20 rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white px-2 py-1 text-sm"
+          placeholder="End" />
+        <span className="text-xs text-gray-400 dark:text-gray-500 ml-1">
+          Optional. Slots missing volumes into this arc when set.
+        </span>
+      </div>
       <div className="flex items-center gap-2 justify-end">
         <button onClick={onCancel} className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Cancel</button>
         <button onClick={save} disabled={saving || !name.trim()}
@@ -4655,6 +4889,7 @@ function BookArcAssigner({ entry, arcs, isOpen, onOpen, onClose, onAssign }: Boo
 
 function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: SeriesDetailViewProps) {
   const { callApi } = useAuth()
+  const { show: showToast } = useToast()
   // Series is fetched on mount so the URL is the source of truth — users can
   // share links straight to a series without going through the list first.
   const [series, setSeries] = useState<Series | null>(null)
@@ -4671,6 +4906,9 @@ function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: Serie
   const [showMetaSearch, setShowMetaSearch] = useState(false)
   const [showAutoMatch, setShowAutoMatch] = useState(false)
   const [showEdit, setShowEdit] = useState(false)
+  const [proposals, setProposals] = useState<AIMetadataProposal[]>([])
+  const [isSuggestingMetadata, setIsSuggestingMetadata] = useState(false)
+  const [isSuggestingArcs, setIsSuggestingArcs] = useState(false)
 
   const deleteSeries = async () => {
     if (!series) return
@@ -4691,17 +4929,63 @@ function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: Serie
   const load = useCallback(async () => {
     setIsLoading(true)
     try {
-      const [list, vols, arcList] = await Promise.all([
+      const [list, vols, arcList, props] = await Promise.all([
         callApi<SeriesEntry[]>(`/api/v1/libraries/${libraryId}/series/${seriesId}/books`),
         callApi<SeriesVolume[]>(`/api/v1/libraries/${libraryId}/series/${seriesId}/volumes`),
         callApi<SeriesArc[]>(`/api/v1/libraries/${libraryId}/series/${seriesId}/arcs`),
+        callApi<AIMetadataProposal[]>(`/api/v1/libraries/${libraryId}/series/${seriesId}/proposals?status=pending`),
       ])
       setEntries(list ?? [])
       setVolumes(vols ?? [])
       setArcs(arcList ?? [])
+      setProposals(props ?? [])
     } catch { /* ignore */ }
     finally { setIsLoading(false) }
   }, [callApi, libraryId, seriesId])
+
+  const suggestSeriesMetadata = async () => {
+    if (isSuggestingMetadata) return
+    setIsSuggestingMetadata(true)
+    try {
+      await callApi(`/api/v1/libraries/${libraryId}/series/${seriesId}/suggest-metadata`, { method: 'POST' })
+      await load()
+      showToast('AI suggestion ready — review below.', { variant: 'success' })
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Failed to call AI provider'
+      showToast(`AI suggestion failed: ${msg}`, { variant: 'error' })
+    } finally {
+      setIsSuggestingMetadata(false)
+    }
+  }
+
+  const suggestSeriesArcs = async () => {
+    if (isSuggestingArcs) return
+    setIsSuggestingArcs(true)
+    try {
+      await callApi(`/api/v1/libraries/${libraryId}/series/${seriesId}/suggest-arcs`, { method: 'POST' })
+      await load()
+      showToast('AI arc suggestion ready — review below.', { variant: 'success' })
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Failed to call AI provider'
+      showToast(`AI arc suggestion failed: ${msg}`, { variant: 'error' })
+    } finally {
+      setIsSuggestingArcs(false)
+    }
+  }
+
+  const acceptProposal = async (proposalID: string, body?: Record<string, unknown>) => {
+    await callApi(`/api/v1/libraries/${libraryId}/proposals/${proposalID}/accept`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined,
+    }).catch(err => console.error('accept proposal failed', err))
+    await Promise.all([load(), reloadSeries()])
+  }
+
+  const rejectProposal = async (proposalID: string) => {
+    await callApi(`/api/v1/libraries/${libraryId}/proposals/${proposalID}/reject`, { method: 'POST' }).catch(() => {})
+    await load()
+  }
 
   // URL is the source of truth — fetch the series on mount or when the id
   // changes. Direct hits to /libraries/{lib}/series/{sid} land here too.
@@ -4771,29 +5055,101 @@ function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: Serie
   let groups: Group[] = []
 
   if (arcs.length > 0) {
-    const sortedArcs = [...arcs].sort((a, b) => a.position - b.position || a.name.localeCompare(b.name))
-    const byArc = new Map<string | null, SeriesEntry[]>()
-    for (const e of entries) {
-      const k = e.arc_id ?? null
-      if (!byArc.has(k)) byArc.set(k, [])
-      byArc.get(k)!.push(e)
+    // Infer which arc a missing volume sits in. Two-tier strategy:
+    //
+    //   1. If any arc has explicit vol_start/vol_end bounds covering this
+    //      position, use that arc. AI proposals carry these bounds, so the
+    //      Final Saga (vols 110–148) properly claims a ghost vol 113 even
+    //      when zero books in that arc are owned.
+    //   2. Otherwise fall back to immediate neighbours: a ghost between two
+    //      owned books in the SAME arc inherits that arc. Anything else
+    //      (mixed arcs, one or both unsorted) leaves the ghost unsorted, to
+    //      be caught by the "Missing volumes" group.
+    const allOwned: Array<{ pos: number; arcID: string | null }> = entries
+      .map(e => ({ pos: e.position, arcID: e.arc_id ?? null }))
+      .sort((a, b) => a.pos - b.pos)
+
+    const inferArcForPos = (p: number): string | null => {
+      // Tier 1 — explicit bounds. Use the most-specific arc when ranges
+      // overlap (smaller span wins on ties).
+      let bestArcID: string | null = null
+      let bestSpan = Infinity
+      for (const arc of arcs) {
+        if (arc.vol_start == null || arc.vol_end == null) continue
+        if (p < arc.vol_start || p > arc.vol_end) continue
+        const span = arc.vol_end - arc.vol_start
+        if (span < bestSpan) {
+          bestSpan = span
+          bestArcID = arc.id
+        }
+      }
+      if (bestArcID) return bestArcID
+
+      // Tier 2 — immediate-neighbour inference for arcs without bounds.
+      let prev: { pos: number; arcID: string | null } | null = null
+      let next: { pos: number; arcID: string | null } | null = null
+      for (const o of allOwned) {
+        if (o.pos < p) prev = o
+        else if (o.pos > p && next === null) { next = o; break }
+      }
+      if (prev && next && prev.arcID && next.arcID && prev.arcID === next.arcID) {
+        return prev.arcID
+      }
+      return null
     }
-    const sortByPos = (a: SeriesEntry, b: SeriesEntry) => a.position - b.position
-    const unsorted = (byArc.get(null) ?? []).slice().sort(sortByPos)
-    if (unsorted.length > 0) {
-      groups.push({ key: 'unsorted', label: 'Unsorted', arcId: null, rows: unsorted.map(e => ({ type: 'entry' as const, entry: e })) })
+
+    // Bucket entries + ghosts together by (inferred) arc_id. Each bucket
+    // ends up containing both real entries and any greyed-out gaps that fall
+    // within its position range, sorted naturally by position.
+    type RowsByKey = Map<string | null, Row[]>
+    const rowsByKey: RowsByKey = new Map()
+    const push = (k: string | null, r: Row) => {
+      if (!rowsByKey.has(k)) rowsByKey.set(k, [])
+      rowsByKey.get(k)!.push(r)
     }
-    for (const arc of sortedArcs) {
-      const arcEntries = (byArc.get(arc.id) ?? []).slice().sort(sortByPos)
-      groups.push({ key: arc.id, label: arc.name, arcId: arc.id, rows: arcEntries.map(e => ({ type: 'entry' as const, entry: e })) })
-    }
-    const ghostRows: Row[] = []
+    for (const e of entries) push(e.arc_id ?? null, { type: 'entry', entry: e })
     for (let i = 1; i <= upperBound; i++) {
-      if (!existingPositions.has(i)) ghostRows.push({ type: 'ghost', position: i, volume: volumeByPosition.get(i) })
+      if (existingPositions.has(i)) continue
+      const arcID = inferArcForPos(i)
+      push(arcID, { type: 'ghost', position: i, volume: volumeByPosition.get(i) })
     }
-    if (ghostRows.length > 0) {
-      groups.push({ key: 'missing', label: 'Missing volumes', arcId: null, rows: ghostRows })
+    const rowPos = (r: Row) => r.type === 'entry' ? r.entry.position : r.position
+    for (const rs of rowsByKey.values()) rs.sort((a, b) => rowPos(a) - rowPos(b))
+
+    // Build all groups (arcs + unsorted + truly-orphan missing) and sort by
+    // their first row's position so reading order flows top-to-bottom.
+    const collected: Array<Group & { sortKey: number }> = []
+    for (const arc of arcs) {
+      const rs = rowsByKey.get(arc.id) ?? []
+      if (rs.length === 0) continue // arc with no books and no inferable gaps
+      collected.push({
+        key: arc.id, label: arc.name, arcId: arc.id,
+        rows: rs,
+        sortKey: rowPos(rs[0]),
+      })
     }
+    const unsortedRows = rowsByKey.get(null) ?? []
+    if (unsortedRows.length > 0) {
+      // Split: real entries in "Unsorted", orphan ghosts in "Missing volumes".
+      const unsortedEntries = unsortedRows.filter(r => r.type === 'entry')
+      const orphanGhosts = unsortedRows.filter(r => r.type === 'ghost')
+      if (unsortedEntries.length > 0) {
+        collected.push({
+          key: 'unsorted', label: 'Unsorted', arcId: null,
+          rows: unsortedEntries,
+          sortKey: rowPos(unsortedEntries[0]),
+        })
+      }
+      if (orphanGhosts.length > 0) {
+        collected.push({
+          key: 'missing', label: 'Missing volumes', arcId: null,
+          rows: orphanGhosts,
+          sortKey: rowPos(orphanGhosts[0]),
+        })
+      }
+    }
+    collected.sort((a, b) => a.sortKey - b.sortKey)
+    groups = collected.map(({ sortKey: _sortKey, ...g }) => g)
   } else {
     // Flat — single group with entries + ghosts interleaved by position.
     const allRows: Row[] = [...entries.map(e => ({ type: 'entry' as const, entry: e }))]
@@ -4835,6 +5191,11 @@ function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: Serie
           className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
           Search metadata
         </button>
+        <button onClick={suggestSeriesMetadata} disabled={isSuggestingMetadata}
+          className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 transition-colors"
+          title="Ask AI to suggest series fields (status, total volumes, demographic, genres, description)">
+          {isSuggestingMetadata ? 'Asking AI…' : 'Suggest with AI'}
+        </button>
         <button onClick={() => setShowEdit(true)}
           className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
           Edit series
@@ -4870,6 +5231,10 @@ function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: Serie
         </div>
       )}
 
+      {/* AI suggestion review panel — surfaces pending proposals so the user
+          can accept/reject before the API writes anything. */}
+      <ProposalsPanel proposals={proposals} existingArcCount={arcs.length} onAccept={acceptProposal} onReject={rejectProposal} />
+
       {/* Arc management panel — collapsed by default. Always available so users
           can add the first arc to a series. */}
       <ArcManagerPanel
@@ -4879,6 +5244,8 @@ function SeriesDetailView({ seriesId, libraryId, setExtraCrumbs, onBack }: Serie
         open={showArcManager}
         onToggle={() => setShowArcManager(o => !o)}
         onChanged={load}
+        onSuggestArcs={suggestSeriesArcs}
+        isSuggesting={isSuggestingArcs}
       />
 
       {!isLoading && hasAnyRows && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,9 +269,50 @@ export interface SeriesArc {
   name: string
   description: string
   position: number
+  // Optional volume bounds — used by the UI to slot ghost rows (missing
+  // volumes the user doesn't own) into the right arc even when no owned
+  // book in the arc is available as a neighbour anchor.
+  vol_start: number | null
+  vol_end: number | null
   book_count: number
   created_at: string
   updated_at: string
+}
+
+// AI-generated proposals for series metadata or arcs. Pending proposals are
+// rendered in a review panel on the series detail page; the user accepts or
+// rejects per-field or per-arc before any structured data is written.
+export interface AIMetadataProposal {
+  id: string
+  library_id: string
+  run_id: string | null
+  target_type: string
+  target_id: string
+  kind: 'series_metadata' | 'series_arcs'
+  payload: SeriesMetadataPayload | SeriesArcsPayload
+  status: 'pending' | 'accepted' | 'rejected' | 'partially_accepted'
+  created_at: string
+  applied_at: string | null
+  applied_by: string | null
+}
+
+export interface SeriesMetadataPayload {
+  status?: string | null
+  total_count?: number | null
+  demographic?: string | null
+  genres: string[]
+  description?: string | null
+}
+
+export interface SeriesArcsPayload {
+  arcs: ProposedArc[]
+}
+
+export interface ProposedArc {
+  name: string
+  position: number
+  vol_start?: number | null
+  vol_end?: number | null
 }
 
 export interface SeriesVolume {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,12 @@ export default defineConfig({
         target: apiTarget,
         changeOrigin: true,
         secure: false,
+        // AI calls (suggest-arcs / suggest-metadata / cleanup) can run 60+
+        // seconds on complex prompts; the default http-proxy timeout was
+        // killing those requests with 502 even though the upstream eventually
+        // returned 201. Allow up to 5 minutes per request.
+        timeout: 5 * 60 * 1000,
+        proxyTimeout: 5 * 60 * 1000,
       },
       '/health': {
         target: apiTarget,


### PR DESCRIPTION
- Series detail surfaces AI suggestion proposals with per-field / per-arc accept; arc re-suggest warns + replaces destructively. Inline arc volume-range editing.
- Jobs history refactored to standard table with type/status filters + pagination; AI cleanup toggle on enrichment-batch and CSV-import surfaces. Depends on librarium-api#34.