### PR TITLE
fix(loans): BookPage polish + drop tag UI

### DIFF
--- a/src/components/LoanFormModal.tsx
+++ b/src/components/LoanFormModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useAuth, ApiError } from '../auth/AuthContext'
-import type { Book, Loan, PagedBooks, Tag } from '../types'
+import type { Book, Loan, PagedBooks } from '../types'
 
 interface LoanFormModalProps {
   libraryId: string
@@ -12,18 +12,6 @@ interface LoanFormModalProps {
   onClose: () => void
   onSaved: () => void
 }
-
-const TAG_COLORS = [
-  { value: '', label: 'Default' },
-  { value: '#ef4444', label: 'Red' },
-  { value: '#f97316', label: 'Orange' },
-  { value: '#eab308', label: 'Yellow' },
-  { value: '#22c55e', label: 'Green' },
-  { value: '#3b82f6', label: 'Blue' },
-  { value: '#8b5cf6', label: 'Purple' },
-  { value: '#ec4899', label: 'Pink' },
-  { value: '#6b7280', label: 'Grey' },
-]
 
 export default function LoanFormModal({ libraryId, loan, prefillBook, onClose, onSaved }: LoanFormModalProps) {
   const { callApi } = useAuth()
@@ -45,32 +33,8 @@ export default function LoanFormModal({ libraryId, loan, prefillBook, onClose, o
     loan ? { id: loan.book_id, title: loan.book_title } : (prefillBook ?? null)
   )
   const [isSearching, setIsSearching] = useState(false)
-  const [libraryTags, setLibraryTags] = useState<Tag[]>([])
-  const [selectedTags, setSelectedTags] = useState<Tag[]>(loan?.tags ?? [])
-  const [newTagName, setNewTagName] = useState('')
-  const [newTagColor, setNewTagColor] = useState('#6b7280')
-  const [showNewTag, setShowNewTag] = useState(false)
-  const [isCreatingTag, setIsCreatingTag] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-
-  useEffect(() => {
-    callApi<Tag[]>(`/api/v1/libraries/${libraryId}/tags`).then(ts => setLibraryTags(ts ?? [])).catch(() => {})
-  }, [callApi, libraryId])
-
-  const createTag = async () => {
-    if (!newTagName.trim()) return
-    setIsCreatingTag(true)
-    try {
-      const tag = await callApi<Tag>(`/api/v1/libraries/${libraryId}/tags`, {
-        method: 'POST',
-        body: JSON.stringify({ name: newTagName.trim(), color: newTagColor }),
-      })
-      if (tag) { setLibraryTags(ts => [...ts, tag]); setSelectedTags(ts => [...ts, tag]) }
-      setNewTagName(''); setShowNewTag(false)
-    } catch { /* ignore */ }
-    finally { setIsCreatingTag(false) }
-  }
 
   // Debounced typeahead — re-fetches as the user types, like the search
   // inputs on BooksTab / SeriesTab. Skips fetching when a book is already
@@ -102,7 +66,6 @@ export default function LoanFormModal({ libraryId, loan, prefillBook, onClose, o
             due_date: form.due_date || null,
             returned_at: loan.returned_at || null,
             notes: form.notes,
-            tag_ids: selectedTags.map(t => t.id),
           }),
         })
       } else {
@@ -114,7 +77,6 @@ export default function LoanFormModal({ libraryId, loan, prefillBook, onClose, o
             loaned_at: form.loaned_at,
             due_date: form.due_date || null,
             notes: form.notes,
-            tag_ids: selectedTags.map(t => t.id),
           }),
         })
       }
@@ -212,49 +174,6 @@ export default function LoanFormModal({ libraryId, loan, prefillBook, onClose, o
               onChange={e => setForm(f => ({ ...f, notes: e.target.value }))}
               className="w-full rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500" />
           </div>
-
-          {libraryTags.length > 0 && (
-            <div>
-              <div className="flex items-center justify-between mb-1.5">
-                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Tags</label>
-                <button type="button" onClick={() => setShowNewTag(v => !v)}
-                  className="text-xs text-blue-600 hover:underline">+ New tag</button>
-              </div>
-              <div className="flex flex-wrap gap-1.5">
-                {libraryTags.map(tag => {
-                  const selected = selectedTags.some(t => t.id === tag.id)
-                  return (
-                    <button key={tag.id} type="button"
-                      onClick={() => setSelectedTags(ts => selected ? ts.filter(t => t.id !== tag.id) : [...ts, tag])}
-                      className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ring-1 transition-all ${
-                        selected ? 'ring-transparent text-white' : 'bg-white dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 text-gray-600 dark:text-gray-300 hover:ring-gray-400'
-                      }`}
-                      style={selected ? { backgroundColor: tag.color || '#6b7280' } : tag.color ? { color: tag.color } : undefined}>
-                      {tag.name}
-                    </button>
-                  )
-                })}
-              </div>
-              {showNewTag && (
-                <div className="mt-2 flex items-center gap-2">
-                  <input type="text" value={newTagName} onChange={e => setNewTagName(e.target.value)}
-                    placeholder="Tag name"
-                    className="flex-1 h-8 rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-2 text-xs focus:border-blue-500 focus:outline-none" />
-                  <select value={newTagColor} onChange={e => setNewTagColor(e.target.value)}
-                    className="h-8 rounded border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white px-2 text-xs focus:border-blue-500 focus:outline-none">
-                    {TAG_COLORS.filter(c => c.value).map(c => (
-                      <option key={c.value} value={c.value}>{c.label}</option>
-                    ))}
-                  </select>
-                  <button type="button" disabled={isCreatingTag || !newTagName.trim()}
-                    onClick={createTag}
-                    className="h-8 px-3 rounded bg-blue-600 text-xs font-medium text-white hover:bg-blue-700 disabled:opacity-50">Add</button>
-                  <button type="button" onClick={() => setShowNewTag(false)}
-                    className="h-8 px-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 text-lg leading-none">×</button>
-                </div>
-              )}
-            </div>
-          )}
 
           {error && <div className="rounded-lg bg-red-50 dark:bg-red-950/50 border border-red-200 dark:border-red-800 px-3 py-2 text-sm text-red-700 dark:text-red-400">{error}</div>}
           <div className="flex gap-3 pt-1">

--- a/src/pages/libraries/BookPage.tsx
+++ b/src/pages/libraries/BookPage.tsx
@@ -1115,8 +1115,10 @@ export default function BookPage() {
     return () => setExtraCrumbs([])
   }, [book, setExtraCrumbs])
 
-  // Lazy-load loan history when the disclosure opens — most books have
-  // no history so we avoid the extra request on the initial book read.
+  // Eager-load loan history alongside the book so we can hide the
+  // section entirely on books that have never been lent. Cheap one-shot
+  // GET; the trade-off vs lazy-loading on disclosure-open is that we
+  // don't render an empty "Loan history" header on books with none.
   // Lives above the early `error` return so hook order stays stable.
   const loadHistory = useCallback(async () => {
     if (!libraryId || !bookId) return
@@ -1126,9 +1128,7 @@ export default function BookPage() {
     setHistory(list ?? [])
   }, [callApi, libraryId, bookId])
 
-  useEffect(() => {
-    if (historyOpen && history === null) loadHistory()
-  }, [historyOpen, history, loadHistory])
+  useEffect(() => { loadHistory() }, [loadHistory])
 
   if (error) {
     return (
@@ -1170,9 +1170,8 @@ export default function BookPage() {
       }),
     }).catch(() => {})
     load()
-    // Drop any cached history so the disclosure refetches and shows the
-    // newly-returned loan in the history list.
-    setHistory(null)
+    // Refresh history so the just-returned loan shows up there too.
+    loadHistory()
   }
 
   const handleCoverDelete = async () => {
@@ -1365,53 +1364,46 @@ export default function BookPage() {
             </Section>
           )}
 
-          {/* Loan history — disclosure pattern, hidden by default since
-              most books have no history. Lazy-fetches on open. */}
-          <div className="pt-6">
-            <button onClick={() => setHistoryOpen(o => !o)}
-              className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
-              <svg className={`w-3.5 h-3.5 transition-transform ${historyOpen ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-              Loan history
-              {history && history.length > 0 && (
+          {/* Loan history — disclosure pattern, collapsed by default.
+              The whole section hides on books with no recorded loans;
+              we eager-fetch above so we know whether to render at all. */}
+          {history && history.length > 0 && (
+            <div className="pt-6">
+              <button onClick={() => setHistoryOpen(o => !o)}
+                className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+                <svg className={`w-3.5 h-3.5 transition-transform ${historyOpen ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+                Loan history
                 <span className="text-xs font-normal normal-case tracking-normal text-gray-400 dark:text-gray-500">
                   ({history.length})
                 </span>
-              )}
-            </button>
-            {historyOpen && (
-              <div className="mt-3">
-                {history === null ? (
-                  <p className="text-sm text-gray-400 dark:text-gray-500">Loading…</p>
-                ) : history.length === 0 ? (
-                  <p className="text-sm text-gray-400 dark:text-gray-500">No loan history yet.</p>
-                ) : (
-                  <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
-                    <table className="w-full text-sm">
-                      <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-                        <tr>
-                          {['Loaned to', 'Loaned', 'Due', 'Returned'].map(h => (
-                            <th key={h} className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{h}</th>
-                          ))}
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
-                        {history.map(loan => (
-                          <tr key={loan.id}>
-                            <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300">{loan.loaned_to}</td>
-                            <td className="px-4 py-2.5 text-xs text-gray-500 dark:text-gray-400">{loan.loaned_at}</td>
-                            <td className="px-4 py-2.5 text-xs text-gray-500 dark:text-gray-400">{loan.due_date ?? <span className="text-gray-300 dark:text-gray-600">—</span>}</td>
-                            <td className="px-4 py-2.5 text-xs text-gray-500 dark:text-gray-400">{loan.returned_at ?? <span className="text-amber-600 dark:text-amber-400">Active</span>}</td>
-                          </tr>
+              </button>
+              {historyOpen && (
+                <div className="mt-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+                      <tr>
+                        {['Loaned to', 'Loaned', 'Due', 'Returned'].map(h => (
+                          <th key={h} className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{h}</th>
                         ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                      {history.map(loan => (
+                        <tr key={loan.id}>
+                          <td className="px-4 py-2.5 text-gray-700 dark:text-gray-300">{loan.loaned_to}</td>
+                          <td className="px-4 py-2.5 text-xs text-gray-500 dark:text-gray-400">{loan.loaned_at}</td>
+                          <td className="px-4 py-2.5 text-xs text-gray-500 dark:text-gray-400">{loan.due_date ?? <span className="text-gray-300 dark:text-gray-600">—</span>}</td>
+                          <td className="px-4 py-2.5 text-xs text-gray-500 dark:text-gray-400">{loan.returned_at ?? <span className="text-amber-600 dark:text-amber-400">Active</span>}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Description */}
           {book.description && (

--- a/src/pages/libraries/BookPage.tsx
+++ b/src/pages/libraries/BookPage.tsx
@@ -1499,7 +1499,14 @@ export default function BookPage() {
           libraryId={libraryId!}
           prefillBook={{ id: book.id, title: book.title }}
           onClose={() => setShowLend(false)}
-          onSaved={() => setShowLend(false)}
+          onSaved={() => {
+            setShowLend(false)
+            // Refresh the book (active_loans) and the history list so the
+            // new loan shows in both the "Currently lent" panel and the
+            // history disclosure without a manual page reload.
+            load()
+            loadHistory()
+          }}
         />
       )}
 

--- a/src/pages/libraries/LibraryPage.tsx
+++ b/src/pages/libraries/LibraryPage.tsx
@@ -5859,12 +5859,6 @@ function LoansTab({ libraryId }: LoansTabProps) {
   const [showNew, setShowNew] = useState(false)
   const [editLoan, setEditLoan] = useState<Loan | null>(null)
   const [search, setSearch] = useState('')
-  const [tagFilter, setTagFilter] = useState('')
-  const [allTags, setAllTags] = useState<Tag[]>([])
-
-  useEffect(() => {
-    callApi<Tag[]>(`/api/v1/libraries/${libraryId}/tags`).then(ts => setAllTags(ts ?? [])).catch(() => {})
-  }, [callApi, libraryId])
 
   // Server returns active-only by default; ask for everything when the
   // status filter could include returned loans, then client-side filter.
@@ -5876,12 +5870,11 @@ function LoansTab({ libraryId }: LoansTabProps) {
       const params = new URLSearchParams()
       params.set('include_returned', String(includeReturned))
       if (search) params.set('search', search)
-      if (tagFilter) params.set('tag', tagFilter)
       const list = await callApi<Loan[]>(`/api/v1/libraries/${libraryId}/loans?${params}`)
       setLoans(list ?? [])
     } catch { /* ignore */ }
     finally { setIsLoading(false) }
-  }, [callApi, libraryId, includeReturned, search, tagFilter])
+  }, [callApi, libraryId, includeReturned, search])
 
   useEffect(() => { load() }, [load])
 
@@ -5966,33 +5959,18 @@ function LoansTab({ libraryId }: LoansTabProps) {
         </div>
       </div>
 
-      {/* Tag chips */}
-      {allTags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mb-4">
-          <button onClick={() => setTagFilter('')} className={filterPill(!tagFilter)}>All tags</button>
-          {allTags.map(tag => (
-            <button key={tag.id}
-              onClick={() => setTagFilter(tagFilter === tag.name ? '' : tag.name)}
-              className={`rounded-full px-2.5 py-1 text-xs font-medium ring-1 transition-all ${tagFilter === tag.name ? 'ring-transparent text-white' : 'bg-white dark:bg-gray-800 ring-gray-300 dark:ring-gray-600 text-gray-600 dark:text-gray-300 hover:ring-gray-400'}`}
-              style={tagFilter === tag.name ? { backgroundColor: tag.color || '#6b7280' } : tag.color ? { color: tag.color } : undefined}>
-              {tag.name}
-            </button>
-          ))}
-        </div>
-      )}
-
       {isLoading && <div className="text-sm text-gray-400 dark:text-gray-500 text-center py-16">Loading…</div>}
 
       {!isLoading && visibleLoans.length === 0 && (
         <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 p-12 text-center">
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
-            {search || tagFilter || overdueFilter !== 'all'
+            {search || overdueFilter !== 'all'
               ? 'No loans match your filters.'
               : statusFilter === 'returned' ? 'No returned loans yet.'
               : statusFilter === 'all' ? 'No loans recorded yet.'
               : 'No active loans.'}
           </p>
-          {!search && !tagFilter && overdueFilter === 'all' && (
+          {!search && overdueFilter === 'all' && (
             <button onClick={() => setShowNew(true)}
               className="text-sm text-blue-600 hover:underline">Record a loan</button>
           )}
@@ -6004,7 +5982,7 @@ function LoansTab({ libraryId }: LoansTabProps) {
           <table className="w-full text-sm">
             <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
               <tr>
-                {['Book', 'Loaned to', 'Tags', 'Loaned', 'Due', showReturnedColumn ? 'Returned' : '', ''].map((h, i) => (
+                {['Book', 'Loaned to', 'Loaned', 'Due', showReturnedColumn ? 'Returned' : '', ''].map((h, i) => (
                   h ? <th key={i} className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{h}</th>
                     : <th key={i} />
                 ))}
@@ -6020,19 +5998,6 @@ function LoansTab({ libraryId }: LoansTabProps) {
                     </Link>
                   </td>
                   <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{loan.loaned_to}</td>
-                  <td className="px-4 py-3">
-                    {loan.tags && loan.tags.length > 0 ? (
-                      <div className="flex flex-wrap gap-1">
-                        {loan.tags.map(tag => (
-                          <span key={tag.id}
-                            className="inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium text-white"
-                            style={{ backgroundColor: tag.color || '#6b7280' }}>
-                            {tag.name}
-                          </span>
-                        ))}
-                      </div>
-                    ) : <span className="text-gray-300 dark:text-gray-600">—</span>}
-                  </td>
                   <td className="px-4 py-3 text-gray-500 dark:text-gray-400 text-xs">{loan.loaned_at}</td>
                   <td className="px-4 py-3 text-xs">
                     {loan.due_date ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -375,7 +375,6 @@ export interface Loan {
   due_date: string | null
   returned_at: string | null
   notes: string
-  tags: Tag[]
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
- BookPage hides the "Loan history" section entirely on books with no recorded loans (eager-fetch on book load, render only when \`history.length > 0\`).
- BookPage refreshes book + history after creating a loan via the Lend button so the new loan appears immediately.
- Drop tag UI from loan modal + LoansTab (Tags section in the form, Tags column + tag chip filter on the tab); pairs with librarium-api#36.